### PR TITLE
Fix removal of services/repos during cleanup

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -651,6 +651,7 @@ def has_repos(smt_server_name):
             if url:
                 if (
                         smt_server_name in url or
+                        'plugin:/susecloud' in url or
                         'plugin:susecloud' in url
                 ):
                     return True
@@ -912,6 +913,7 @@ def __get_referenced_credentials(smt_server_name):
                 if (
                         (
                             smt_server_name in url or
+                            'plugin:/susecloud' in url or
                             'plugin:susecloud' in url
                         ) and 'credentials=' in url
                 ):
@@ -981,6 +983,7 @@ def __remove_repos(smt_server_name):
             if url:
                 if (
                         smt_server_name in url or
+                        'plugin:/susecloud' in url or
                         'plugin:susecloud' in url
                 ):
                     logging.info(
@@ -1003,6 +1006,7 @@ def __remove_service(smt_server_name):
             if url:
                 if (
                         smt_server_name in url or
+                        'plugin:/susecloud' in url or
                         'plugin:susecloud' in url
                 ):
                     logging.info('Removing service: %s'


### PR DESCRIPTION
Currently services/repos aren't being removed when `registercloudguest --force-new` is invoked. [RMT returns URLs](https://github.com/SUSE/rmt/blob/d1f1000ab099154a4243f123277ff3259be8c130/engines/zypper_auth/lib/zypper_auth/engine.rb#L59) in `plugin:/susecloud` format, rather than `plugin:susecloud`.

