### PR TITLE
Avoid parse error

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -995,7 +995,6 @@ def __remove_repos(smt_server_name):
 def __remove_service(smt_server_name):
     """Remove the services pointing to the update infrastructure"""
     service_files = glob.glob('/etc/zypp/services.d/*')
-    service_files += glob.glob('/usr/lib/zypp/plugins/services/*')
     for service_file in service_files:
         service_cfg = get_config(service_file)
         for section in service_cfg.sections():


### PR DESCRIPTION
Closes #8 

The plugin links were treated as INI files thus causing a parser error. This broke the '--forec-new' functionality