### PR TITLE
intial suggestion

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -136,15 +136,14 @@ def clear_new_registration_flag():
 
 
 # ----------------------------------------------------------------------------
-def credentials_files_are_equal():
-    """Compare all the credentials files and make sure they have the same
+def credentials_files_are_equal(in_credential):
+    """Compare the base credentials files the the repo header and make sure they have the same
        values."""
-    credentials_files = glob.glob('/etc/zypp/credentials.d/*')
-    if credentials_files:
-        base = credentials_files[0]
-        for credential_file in credentials_files[1:]:
-            if not filecmp.cmp(base, credential_file):
-                return False
+    credentials_location = '/etc/zypp/credentials.d/'
+    credentials_base     = credentials_location + 'SCCcredentials'
+    credentials_header   = credentials_location + in_credential
+    if not filecmp.cmp(credentials_base, credentials_header):
+        return False
 
     return True
 

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -136,12 +136,12 @@ def clear_new_registration_flag():
 
 
 # ----------------------------------------------------------------------------
-def credentials_files_are_equal(in_credential):
+def credentials_files_are_equal(repo_credentials):
     """Compare the base credentials files the the repo header and make sure they have the same
        values."""
     credentials_location = '/etc/zypp/credentials.d/'
     credentials_base     = credentials_location + 'SCCcredentials'
-    credentials_header   = credentials_location + in_credential
+    credentials_header   = credentials_location + repo_credentials
     if not filecmp.cmp(credentials_base, credentials_header):
         return False
 

--- a/usr/lib/zypp/plugins/urlresolver/susecloud
+++ b/usr/lib/zypp/plugins/urlresolver/susecloud
@@ -39,13 +39,14 @@ class SUSECloudPlugin(Plugin):
         verify_credentials = False
         zypper_pid = utils.get_zypper_pid()
         prev_zypper_pid = utils.get_zypper_pid_cache()
+        repo_credentials = headers.get('credentials')
         if zypper_pid != prev_zypper_pid:
             verify_credentials = True
         # Note this logic breaks when FATE#320882/PM-1251 gets implemented
-        if verify_credentials and not utils.credentials_files_are_equal(headers.get('credentials')):
+        if verify_credentials and not utils.credentials_files_are_equal(repo_credentials):
             self.error(
                 {'CREDENTIAL_ERROR': 'INCONSISTENT'},
-                'Not all credentials files are eqivalent: %s' % headers.get('credentials')
+                'Not all credentials files are eqivalent: %s' % repo_credentials
             )
             return
         server_name = ''
@@ -62,12 +63,11 @@ class SUSECloudPlugin(Plugin):
         if server_name:
             srv_url = 'https://%s' % server_name
             repo_url = srv_url + headers.get('path')
-            credentials = headers.get('credentials')
-            if credentials:
-                repo_url += '?credentials=' + credentials
+            if repo_credentials:
+                repo_url += '?credentials=' + repo_credentials
                 if verify_credentials:
                     credentials_file_path = (
-                        '/etc/zypp/credentials.d/%s' % credentials
+                        '/etc/zypp/credentials.d/%s' % repo_credentials
                     )
                     user, password = utils.get_credentials(
                         credentials_file_path

--- a/usr/lib/zypp/plugins/urlresolver/susecloud
+++ b/usr/lib/zypp/plugins/urlresolver/susecloud
@@ -42,10 +42,10 @@ class SUSECloudPlugin(Plugin):
         if zypper_pid != prev_zypper_pid:
             verify_credentials = True
         # Note this logic breaks when FATE#320882/PM-1251 gets implemented
-        if verify_credentials and not utils.credentials_files_are_equal():
+        if verify_credentials and not utils.credentials_files_are_equal(headers.get('credentials')):
             self.error(
                 {'CREDENTIAL_ERROR': 'INCONSISTENT'},
-                'Not all credentials files are eqivalent'
+                'Not all credentials files are eqivalent: %s' % headers.get('credentials')
             )
             return
         server_name = ''


### PR DESCRIPTION
This is a suggested fix to issue #20 

Since the plugin is run on every url resolution the check can be made only for the specific credential file corresponding to the repo being validated. This avoids accidental checks of other private repo credential files