### PR TITLE
Use %license macro in specfile

### DIFF
--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -126,7 +126,8 @@ mkdir -p %{buildroot}/var/lib/cloudregister
 
 %files
 %defattr(-,root,root,-)
-%doc README LICENSE
+%doc README
+%license LICENSE
 %dir %{_usr}/lib/zypp
 %dir %{_usr}/lib/zypp/plugins
 %dir %{_usr}/lib/zypp/plugins/urlresolver


### PR DESCRIPTION
```
(W) found COPYING or LICENSE file marked as %doc, please mark as %license instead
LINE is: "%doc README LICENSE"
```