### PR TITLE
Expose SMT response on registration failure

### DIFF
--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -482,11 +482,11 @@ res = requests.get(
 )
 if res.status_code != 200:
     err_msg = 'Unable to obtain product information from server "%s"\n'
-    err_msg += '\t%s\nUnable to register modules, exiting.'
+    err_msg += '\t%s\n\t%s\nUnable to register modules, exiting.'
     ips = '%s,%s' % (
         registration_target.get_ipv4(), registration_target.get_ipv6()
     )
-    logging.error(err_msg % (ips, res.reason))
+    logging.error(err_msg % (ips, res.reason, res.content.decode("UTF-8")))
     sys.exit(1)
 
 prod_data = json.loads(res.text)


### PR DESCRIPTION
The HTTP response reason is too generic and doesn't help identify the root cause of registration issues. This change adds the response content from the SMT server to expose the underlying issue.

Example issue (easily reproducible):
1. Change the symlink of the baseproduct symlink to anything other than the main SLES product in /etc/products.d (sudo ln -sfn sle-module-toolchain.prod baseproduct)
2. run sudo registercloudguest --force-new
3. you'll find a generic error in cloudregister logs:
```
2020-05-19 04:49:14,009 ERROR:Unable to obtain product information from server "[SMT target server IP],None"
        Unprocessable Entity
Unable to register modules, exiting.
```

This is masking the underlying error that we actually get from the SMT response's content:
```
b'{"type":"error","error":"Unmet product dependencies, activate one of these products first: SUSE Linux Enterprise Server 12 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 x86_64, SUSE Linux Enterprise Server 12 SP1 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP1 x86_64, SUSE Linux Enterprise Server 12 SP2 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP2 x86_64, SUSE Linux Enterprise Server 12 SP3 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP3 x86_64, SUSE Linux Enterprise Server 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP2 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP3 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP5 x86_64, SUSE Linux Enterprise Server 12 SP5 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP5 x86_64","localized_error":"Unmet product dependencies, activate one of these products first: SUSE Linux Enterprise Server 12 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 x86_64, SUSE Linux Enterprise Server 12 SP1 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP1 x86_64, SUSE Linux Enterprise Server 12 SP2 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP2 x86_64, SUSE Linux Enterprise Server 12 SP3 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP3 x86_64, SUSE Linux Enterprise Server 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP2 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP3 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP5 x86_64, SUSE Linux Enterprise Server 12 SP5 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP5 x86_64"}'
```

This proposed change adds this response content right under the response reason in the log, so it would look like this:
```
2020-05-19 04:49:14,009 ERROR:Unable to obtain product information from server "[SMT target server IP],None"
        Unprocessable Entity
       {"type":"error","error":"Unmet product dependencies, activate one of these products first: SUSE Linux Enterprise Server 12 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 x86_64, SUSE Linux Enterprise Server 12 SP1 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP1 x86_64, SUSE Linux Enterprise Server 12 SP2 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP2 x86_64, SUSE Linux Enterprise Server 12 SP3 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP3 x86_64, SUSE Linux Enterprise Server 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP2 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP3 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP5 x86_64, SUSE Linux Enterprise Server 12 SP5 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP5 x86_64","localized_error":"Unmet product dependencies, activate one of these products first: SUSE Linux Enterprise Server 12 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 x86_64, SUSE Linux Enterprise Server 12 SP1 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP1 x86_64, SUSE Linux Enterprise Server 12 SP2 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP2 x86_64, SUSE Linux Enterprise Server 12 SP3 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP3 x86_64, SUSE Linux Enterprise Server 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP2 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP3 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP4 x86_64, SUSE Linux Enterprise High Performance Computing 12 SP5 x86_64, SUSE Linux Enterprise Server 12 SP5 x86_64, SUSE Linux Enterprise Server for SAP Applications 12 SP5 x86_64"}
Unable to register modules, exiting.
```