### PR TITLE
Introduce containerbuild-regionsrv service

### DIFF
--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -114,17 +114,17 @@ install -m 644 man/man1/* %{buildroot}/%{_mandir}/man1
 gzip %{buildroot}/%{_mandir}/man1/*
 
 %pre
-%service_add_pre guestregister.service
+%service_add_pre guestregister.service containerbuild-regionsrv.service
 
 %post
 /usr/sbin/switchcloudguestservices
-%service_add_post guestregister.service
+%service_add_post guestregister.service containerbuild-regionsrv.service
 
 %preun
-%service_del_preun guestregister.service
+%service_del_preun guestregister.service containerbuild-regionsrv.service
 
 %postun
-%service_del_postun guestregister.service
+%service_del_postun guestregister.service containerbuild-regionsrv.service
 
 %files
 %defattr(-,root,root,-)
@@ -135,6 +135,7 @@ gzip %{buildroot}/%{_mandir}/man1/*
 %dir %{_usr}/lib/zypp/plugins/urlresolver
 %dir /var/lib/cloudregister
 %{_mandir}/man*/*
+%{_sbindir}/containerbuild-regionsrv
 %{_sbindir}/cloudguest-repo-service
 %{_sbindir}/switchcloudguestservices
 %{_sbindir}/registercloudguest
@@ -144,6 +145,7 @@ gzip %{buildroot}/%{_mandir}/man1/*
 %{python3_sitelib}/cloudregister/smt*
 %{python3_sitelib}/cloudregister/VERSION
 %{_unitdir}/guestregister.service
+%{_unitdir}/containerbuild-regionsrv.service
 %dir %{python3_sitelib}/cloudregister-%{base_version}-py%{py3_ver}.egg-info
 %dir %{python3_sitelib}/cloudregister/
 %{python3_sitelib}/cloudregister-%{base_version}-py%{py3_ver}.egg-info/*

--- a/usr/lib/systemd/system/containerbuild-regionsrv.service
+++ b/usr/lib/systemd/system/containerbuild-regionsrv.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Provides Cloud SMT info and credentials to container build tools
+After=network-online.target guestregister.service
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/sbin/containerbuild-regionsrv
+Type=simple
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/lib/systemd/system/containerbuild-regionsrv.service
+++ b/usr/lib/systemd/system/containerbuild-regionsrv.service
@@ -4,6 +4,7 @@ After=network-online.target guestregister.service
 Wants=network-online.target
 
 [Service]
+EnvironmentFile=-/etc/sysconfig/containerbuild-regionsrv
 ExecStart=/usr/sbin/containerbuild-regionsrv
 Type=simple
 

--- a/usr/sbin/containerbuild-regionsrv
+++ b/usr/sbin/containerbuild-regionsrv
@@ -19,7 +19,22 @@ import base64
 import os
 import socketserver
 import json
+import logging
+import urllib3
 
+# Disable the urllib warnings
+# We have server certs that have no subject alt names
+# cloudregister.registerutils() checks the server state API without
+# certificate validation
+urllib3.disable_warnings()
+
+loglevel = os.getenv("CONTAINER_BUILD_LOGLEVEL", "INFO")
+
+logging.basicConfig(level=loglevel,
+                    format='%(levelname)s: %(message)s'
+                    )
+
+LOG = logging.getLogger('containerbuild-regionsrv')
 
 class ContainerBuildTCPServer(socketserver.BaseRequestHandler):
     """
@@ -54,8 +69,9 @@ class ContainerBuildTCPServer(socketserver.BaseRequestHandler):
         except AttributeError as err:
             # This is the exception being raised whenever there is something
             # really off about the SMT (because of the internal implementation).
-            print(
-                "Catched exception while obtaining SMT server: {0}".format(err))
+            LOG.warn(
+                "Caught exception while obtaining SMT server: {0}".format(err)
+            )
             smt = None
 
         username, password = self.get_credentials()

--- a/usr/sbin/containerbuild-regionsrv
+++ b/usr/sbin/containerbuild-regionsrv
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+# -*- encoding: utf-8 -*-
+
+# Copyright (c) 2020 SUSE LLC.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import cloudregister.registerutils as utils
+import base64
+import os
+import socketserver
+import json
+
+
+class ContainerBuildTCPServer(socketserver.BaseRequestHandler):
+    """
+    A TCP server that emits configuration details that are relevant to
+    SUSEConnect.
+    """
+
+    def instance_data_header(self):
+        """
+        Returns the instance data as retrieved from the SMT server.
+        """
+
+        instance_data = bytes(utils.get_instance_data(utils.get_config()), 'utf-8')
+        return base64.b64encode(instance_data).decode()
+
+    def get_credentials(self):
+        """
+        Returns the SCC credentials as stored in
+        /etc/zypp/credentials.d/SCCcredentials
+        """
+        credentials_file_path = '/etc/zypp/credentials.d/SCCcredentials'
+        return utils.get_credentials(credentials_file_path)
+
+    def handle(self):
+        """
+        This is the method being called for each request. It returns a JSON response
+        with all the relevant information.
+        """
+
+        try:
+            smt = utils.get_smt()
+        except AttributeError as err:
+            # This is the exception being raised whenever there is something
+            # really off about the SMT (because of the internal implementation).
+            print(
+                "Catched exception while obtaining SMT server: {0}".format(err))
+            smt = None
+
+        username, password = self.get_credentials()
+
+        if smt is None:
+            resp = {}
+        else:
+            resp = {
+                'instance-data': self.instance_data_header(),
+                "server-fqdn": smt.get_FQDN(),
+                'server-ip': smt.get_ipv4(),
+                'username': username,
+                'password': password,
+                'ca': smt.get_cert()
+            }
+
+        self.request.sendall(bytes(json.dumps(resp), 'utf-8'))
+
+
+def main():
+    """
+    main entry point of the program.
+    """
+
+    ip = os.getenv("CONTAINER_BUILD_IP", '127.0.0.1')
+    port = int(os.getenv("CONTAINER_BUILD_PORT", 7956))
+
+    socketserver.TCPServer.allow_reuse_address = True
+
+    with socketserver.TCPServer((ip, port), ContainerBuildTCPServer) as server:
+        server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This provides a small service can be used by container building tools like "docker" or "podman build" to obtain the required info for being able to install packages inside the container image using the Public Cloud RMTs. It is susposed to be used in conjunction with "container-suseconnect" when building images inside on-demand public cloud instances.

This goes together with a couple of changes in container-suseconnect which we're currently finalizing in https://github.com/SUSE/container-suseconnect/tree/new-authentication-scheme.