### PR TITLE
Fix containerbuild-regionsrv for SLE12

### DIFF
--- a/usr/sbin/containerbuild-regionsrv
+++ b/usr/sbin/containerbuild-regionsrv
@@ -101,8 +101,8 @@ def main():
 
     socketserver.TCPServer.allow_reuse_address = True
 
-    with socketserver.TCPServer((ip, port), ContainerBuildTCPServer) as server:
-        server.serve_forever()
+    server = socketserver.TCPServer((ip, port), ContainerBuildTCPServer)
+    server.serve_forever()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The Python release available on SLE12 (3.4.x) does not support the
"context manager" protocol. Rework the code to something backwards
compatible.

Closes #36