### PR TITLE
Add support for no_proxy env variable

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -937,8 +937,11 @@ def set_proxy():
             http_proxy = entry.split('"')[1]
         if 'HTTPS_PROXY' in entry:
             https_proxy = entry.split('"')[1]
+        if 'NO_PROXY' in entry:
+            no_proxy = entry.split('"')[1]
     os.environ['http_proxy'] = http_proxy
     os.environ['https_proxy'] = https_proxy
+    os.environ['no_proxy'] = no_proxy
 
     return True
 

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -243,8 +243,10 @@ proxy = utils.set_proxy()
 if proxy:
     http_proxy = os.environ.get('http_proxy')
     https_proxy = os.environ.get('https_proxy')
+    no_proxy = os.environ.get('no_proxy')
     proxies = {'http_proxy': http_proxy,
-               'https_proxy': https_proxy}
+               'https_proxy': https_proxy,
+               'no_proxy': no_proxy}
     logging.info('Using proxy settings: %s' % proxies)
 
 if args.user_smt_ip:


### PR DESCRIPTION
Currently registercloudguest command doesn't read NO_PROXY from /etc/sysconfig/proxy file.  This will cause EC2 metadata requests being sent to proxy despite NO_PROXY configuration exist in the proxy config file to bypass proxy for EC2 metadata requests. Reading NO_PROXY from the proxy config file and set it to the environment should fix this issue.