### PR TITLE
New package to enable/disable access due to AHB

### DIFF
--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -97,6 +97,17 @@ Requires:       python3-dnspython
 %description plugin-azure
 Guest registration plugin for images intended for Microsoft Azure
 
+%package addon-azure
+Version:	0.0.1
+Release:	0
+Summary:	Enable/Disable Guest Registration for Microsoft Azure
+Group:		Productivity/Networking/Web/Servers
+Requires:	cloud-regionsrv-client >= 9.0.0
+Requires:	cloud-regionsrv-client-plugin-azure
+
+%description addon-azure
+Enable/Disable Guest Registration for Microsoft Azure
+
 %prep
 %setup -q
 
@@ -111,21 +122,35 @@ mkdir -p %{buildroot}/var/lib/regionService/certs
 mkdir -p %{buildroot}/var/lib/cloudregister
 install -d -m 755 %{buildroot}/%{_mandir}/man1
 install -m 644 man/man1/* %{buildroot}/%{_mandir}/man1
+install -m 644 usr/lib/systemd/system/regionsrv-enabler.service %{buildroot}%{_unitdir}
+install -m 644 usr/lib/systemd/system/regionsrv-enabler.timer %{buildroot}%{_unitdir}
 gzip %{buildroot}/%{_mandir}/man1/*
 
 %pre
 %service_add_pre guestregister.service containerbuild-regionsrv.service
+
+%pre addon-azure
+%service_add_pre regionsrv-enabler.timer
 
 %post
 %{_sbindir}/switchcloudguestservices
 %{_sbindir}/updatesmtcache
 %service_add_post guestregister.service containerbuild-regionsrv.service
 
+%post addon-azure
+%service_add_post regionsrv-enabler.timer
+
 %preun
 %service_del_preun guestregister.service containerbuild-regionsrv.service
 
+%preun addon-azure
+%service_del_preun regionsrv-enabler.timer
+
 %postun
 %service_del_postun guestregister.service containerbuild-regionsrv.service
+
+%postun addon-azure
+%service_del_postun regionsrv-enabler.timer
 
 %files
 %defattr(-,root,root,-)
@@ -169,5 +194,12 @@ gzip %{buildroot}/%{_mandir}/man1/*
 %files plugin-azure
 %defattr(-,root,root,-)
 %{python3_sitelib}/cloudregister/msft*
+
+%files addon-azure
+%defattr(-,root,root,-)
+%{_unitdir}/regionsrv-enabler.service
+%{_unitdir}/regionsrv-enabler.timer
+%attr(744, root, root) %{_sbindir}/regionsrv-enabler
+
 
 %changelog

--- a/usr/lib/systemd/system/regionsrv-enabler.service
+++ b/usr/lib/systemd/system/regionsrv-enabler.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Enable/Disable Guest Registration for Microsoft Azure
+After=network-online.target
+Wants=network-online.target
+StartLimitIntervalSec=500
+StartLimitBurst=5
+
+[Service]
+ExecStart=/usr/sbin/regionsrv-enabler
+Type=simple
+Restart=on-failure
+RestartSec=5s
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/lib/systemd/system/regionsrv-enabler.timer
+++ b/usr/lib/systemd/system/regionsrv-enabler.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Enable/Disable Guest Registration for Microsoft Azure timer
+After=network-online.target
+Requires=network-online.target guestregister.service
+
+[Timer]
+OnCalendar=*:0/1
+AccuracySec=1
+Unit=regionsrv-enabler.service
+
+[Install]
+WantedBy=multi-user.target

--- a/usr/sbin/regionsrv-enabler
+++ b/usr/sbin/regionsrv-enabler
@@ -1,0 +1,107 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2021, SUSE LLC, All rights reserved.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+import logging
+import os
+import requests
+import subprocess
+import sys
+
+
+def start_logging():
+    log_filename = '/var/log/cloudaccess'
+    try:
+        logging.basicConfig(
+            filename=log_filename,
+            level=logging.INFO,
+            format='%(asctime)s %(levelname)s:%(message)s'
+        )
+    except IOError:
+        print('Could not open log file "{}" for writing.'.format(log_filename))
+        sys.exit(1)
+
+
+def get_license_type():
+    proxies = {
+        'http': None,
+        'https': None
+    }
+    headers = {'Metadata': 'true'}
+    imds_server_base_url = 'http://169.254.169.254'
+
+    instance_api_version = '2021-03-01'
+    instance_endpoint = '{base_url}/metadata/instance/compute/licenseType?' \
+        'api-version={api_version}&format=text'.format(
+            base_url=imds_server_base_url,
+            api_version=instance_api_version
+        )
+
+    res = requests.get(instance_endpoint, headers=headers, proxies=proxies)
+
+    if res.status_code != 200:
+        logging.error('Unable to obtain instance metadata')
+        sys.exit(1)
+
+    return res.text
+
+
+def run_command(command):
+    logging.info('Calling {}'.format(command))
+    try:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            env=os.environ
+        )
+    except Exception as issue:
+        logging.error(
+            'EXEC: Exception running command {0} with issue: {1}: {2}'.format(
+                ' '.join(command), type(issue).__name__, issue
+            )
+        )
+        sys.exit(1)
+
+    output, error = process.communicate()
+    if process.returncode != 0 and error.decode():
+        logging.error(
+            'EXEC: Failed with stderr: {0}, stdout: {1}'.format(
+                error.decode(), output.decode()
+            )
+        )
+        sys.exit(1)
+    output = output.decode()
+    output = output.replace('\n', '')
+    return output
+
+
+start_logging()
+service_name = 'guestregister'
+license_type = get_license_type()
+
+if 'BYOS' in license_type:
+    if run_command(['systemctl', 'is-enabled', service_name]) == 'enabled':
+        run_command(
+            ['registercloudguest', '--clean']
+        )
+        run_command(
+            ['systemctl', 'disable', service_name]
+        )
+elif run_command(['systemctl', 'is-enabled', service_name]) == 'disabled':
+    run_command(
+        ['registercloudguest', '--force-new']
+    )
+    run_command(
+        ['systemctl', 'enable', service_name]
+    )


### PR DESCRIPTION
A package running with a timer to enable/disable
the access to the infrastructure from Azure instances.

If running instance is MSFT and the license type
is BYOS, guestregister service is not enable and
the infra repositories are not available.

This references bsc#1182026