### PR TITLE
Added registration availability check

### DIFF
--- a/etc/regionserverclnt.cfg
+++ b/etc/regionserverclnt.cfg
@@ -10,3 +10,4 @@ instanceArgs = none
 
 [service]
 verifyAccess = none
+supportsPackageBackend = zypper

--- a/etc/regionserverclnt.cfg
+++ b/etc/regionserverclnt.cfg
@@ -10,4 +10,4 @@ instanceArgs = none
 
 [service]
 verifyAccess = none
-supportsPackageBackend = zypper
+packageBackend = zypper

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -1118,7 +1118,7 @@ def is_registration_supported(cfg):
       Indicates a product of the RHEL family for which we do not
       provide subscription management.
     """
-    package_backend = cfg.get('service', 'supportsPackageBackend')
+    package_backend = cfg.get('service', 'packageBackend')
     registration_supported = True
     if package_backend == 'dnf':
         logging.info('Registration for RHEL product family requested')

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -1104,6 +1104,30 @@ def update_ca_chain(cmd_w_args_lst):
     return 0
 
 
+# ----------------------------------------------------------------------------
+def is_registration_supported(cfg):
+    """
+    Check if a registration process is available
+    based on the supported package manager backend
+
+    zypper:
+      Indicates a SUSE/SLES system including the registration
+      process based on SUSEConnect and /etc/products.d/baseproduct
+
+    dnf:
+      Indicates a product of the RHEL family for which we do not
+      provide subscription management.
+    """
+    package_backend = cfg.get('service', 'supportsPackageBackend')
+    registration_supported = True
+    if package_backend == 'dnf':
+        logging.info('Registration for RHEL product family requested')
+        logging.info('Exit after repository server hosts entry setup')
+        registration_supported = False
+
+    return registration_supported
+
+
 # Private
 # ----------------------------------------------------------------------------
 def __get_referenced_credentials(smt_server_name):

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -30,10 +30,10 @@ cfg = get_config('../etc/regionserverclnt.cfg')
 
 
 def test_is_registration_supported_SUSE_Family():
-    cfg.set('service', 'supportsPackageBackend', 'zypper')
+    cfg.set('service', 'packageBackend', 'zypper')
     assert is_registration_supported(cfg) is True
 
 
 def test_is_registration_supported_RHEL_Family():
-    cfg.set('service', 'supportsPackageBackend', 'dnf')
+    cfg.set('service', 'packageBackend', 'dnf')
     assert is_registration_supported(cfg) is False

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2021 SUSE Software Solutions Germany GmbH. All rights reserved.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+
+import inspect
+import os
+import sys
+
+test_path = os.path.abspath(
+    os.path.dirname(inspect.getfile(inspect.currentframe())))
+code_path = os.path.abspath('%s/../lib' % test_path)
+
+sys.path.insert(0, code_path)
+
+from cloudregister.registerutils import (
+    get_config,
+    is_registration_supported
+)
+
+cfg = get_config('../etc/regionserverclnt.cfg')
+
+
+def test_is_registration_supported_SUSE_Family():
+    cfg.set('service', 'supportsPackageBackend', 'zypper')
+    assert is_registration_supported(cfg) is True
+
+
+def test_is_registration_supported_RHEL_Family():
+    cfg.set('service', 'supportsPackageBackend', 'dnf')
+    assert is_registration_supported(cfg) is False

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -411,6 +411,11 @@ if instance_data:
     inst_data_out.write(instance_data)
     inst_data_out.close()
 
+# Check if registration is supported
+if not utils.is_registration_supported(cfg):
+    sys.exit(0)
+
+# Check SUSE/SLES registration command to be present
 register_cmd = '/usr/sbin/SUSEConnect'
 if not (os.path.exists(register_cmd) and os.access(register_cmd, os.X_OK)):
     logging.error('No registration executable found')


### PR DESCRIPTION
Added util method is_registration_supported() which checks
if a registration process is available based on the supported
package manager backend. This change helps to configure the
behavior of registercloudguest on non SUSE based products.
Product families for which there is no subscription/registration process available will
exit after the repository hosts setup from registercloudguest