### PR TITLE
- Do not report false positives for credential access

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -473,7 +473,10 @@ def get_credentials(credentials_file):
     username = None
     password = None
     if not os.path.exists(credentials_file):
-        logging.error('Credentials file not found: "%s"' % credentials_file)
+        if not is_new_registration():
+            logging.error(
+                'Credentials file not found: "%s"' % credentials_file
+            )
         return (username, password)
     credentials = open(credentials_file).readlines()
     for entry in credentials:


### PR DESCRIPTION
  + During initial registration against a specific server credential access
    is probed triggering an error in the log file. However, during first
    registration we expect to have no credentials and as such no error
    should be reported