### PR TITLE
Adapt to interface changes for is_registered()

### DIFF
--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -99,7 +99,7 @@ Requires:       python3-dnspython
 Guest registration plugin for images intended for Microsoft Azure
 
 %package addon-azure
-Version:	1.0.1
+Version:	1.0.2
 Release:	0
 Summary:	Enable/Disable Guest Registration for Microsoft Azure
 Group:		Productivity/Networking/Web/Servers

--- a/lib/cloudregister/msftazure.py
+++ b/lib/cloudregister/msftazure.py
@@ -12,6 +12,7 @@
 # License along with this library.
 
 import dns.resolver
+import html
 import logging
 import requests
 import re
@@ -85,9 +86,8 @@ def generateRegionSrvArgs():
             if not match:
                 logging.warning('No "<ExtensionsConfig>" in goal state XML')
                 continue
-            h = HTMLParser()
             extensionsURI = urllib.parse.unquote(
-                h.unescape(match.groups()[0])
+                html.unescape(match.groups()[0])
             )
             try:
                 extensionsResp = requests.get(

--- a/tests/test_azureplugin.py
+++ b/tests/test_azureplugin.py
@@ -307,9 +307,7 @@ def _get_proper_extensions_response(upper = False):
         region = region.upper()
     response.status_code = 200
     data = 'the_doc '
-    data += '<Location>useast</Location>'
-    if upper:
-        data += '<Location>USEAST</Location>'
+    data += '<Location>{0}</Location>'.format(region)
     data += 'last'
     response.text = data
     return response

--- a/tests/test_azureplugin.py
+++ b/tests/test_azureplugin.py
@@ -307,7 +307,9 @@ def _get_proper_extensions_response(upper = False):
         region = region.upper()
     response.status_code = 200
     data = 'the_doc '
-    data += f"<Location>{region}</Location>"
+    data += '<Location>useast</Location>'
+    if upper:
+        data += '<Location>USEAST</Location>'
     data += 'last'
     response.text = data
     return response

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -18,6 +18,7 @@ import sys
 test_path = os.path.abspath(
     os.path.dirname(inspect.getfile(inspect.currentframe())))
 code_path = os.path.abspath('%s/../lib' % test_path)
+config_path = os.path.abspath('%s/../etc' % test_path)
 
 sys.path.insert(0, code_path)
 
@@ -26,7 +27,7 @@ from cloudregister.registerutils import (
     is_registration_supported
 )
 
-cfg = get_config('../etc/regionserverclnt.cfg')
+cfg = get_config(config_path + '/regionserverclnt.cfg')
 
 
 def test_is_registration_supported_SUSE_Family():

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -86,7 +86,7 @@ elif license_type and 'BYOS' not in license_type:
     # or PAYG without AHB
     update_server = utils.get_smt()
     if update_server:
-        if utils.is_registered(update_server):
+        if utils.is_registered(update_server.get_FQDN()):
             sys.exit(0)
         update_server = None
     if not update_server:


### PR DESCRIPTION
The interface for is_registered expects a string of the FQDN for the update server, it no longer takes and object
