### PR TITLE
Provide warning message on empty metadata

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -600,6 +600,11 @@ def get_instance_data(config):
                     errMsg = 'Data collected from stderr for instance '
                     errMsg += 'data collection "%s"' % errors
                     logging.error(errMsg)
+                if not instance_data:
+                    warn_msg = 'Possible issue accessing the metadata service.'
+                    warn_msg += ' Metadata is empty, may result in '
+                    warn_msg += 'registration failure.'
+                    logging.warning(warn_msg)
 
     # Marker for the server to not return https:// formated
     # service and repo information


### PR DESCRIPTION
+ When a instance data provider is configured but the collected data is
  empty it is highly likely that registration will fail. Provide a warning
  message indicating the data collection issue.