### PR TITLE
Remvoe enabler dependency on the registration service

### DIFF
--- a/usr/lib/systemd/system/regionsrv-enabler-azure.timer
+++ b/usr/lib/systemd/system/regionsrv-enabler-azure.timer
@@ -1,7 +1,7 @@
 [Unit]
 Description=Enable/Disable Guest Registration for Microsoft Azure timer
 After=network-online.target
-Requires=network-online.target guestregister.service
+Requires=network-online.target
 
 [Timer]
 OnCalendar=*:0/1


### PR DESCRIPTION
+ The enabler for the repos is an independent service and must remain
  independent such that the registration can be enabled in code under the
  pre-determined conditions.