### PR TITLE
Update clean credentials

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -1272,17 +1272,13 @@ def __get_referenced_credentials(smt_server_name):
             url = repo_cfg.get(section, 'baseurl')
             if url:
                 if (
-                        (
-                            smt_server_name in url or
-                            'plugin:/susecloud' in url or
-                            'plugin:susecloud' in url
-                        ) and 'credentials=' in url
+                        smt_server_name in url or
+                        'plugin:/susecloud' in url or
+                        'plugin:susecloud' in url
                 ):
-                    line_parts = url.split('?credentials=')
-                    if len(line_parts) > 1:
-                        credentials_name = line_parts[-1].split('&')[0]
-                        if credentials_name not in referenced_credentials:
-                            referenced_credentials.append(credentials_name)
+                    credentials_name = repo_cfg.get(section, 'service')
+                    if credentials_name not in referenced_credentials:
+                        referenced_credentials.append(credentials_name)
 
     return referenced_credentials
 


### PR DESCRIPTION
- Problem: When running registercloudguest --clean in a
  BYOS instance, some credentials were not removed

- No need to separate PAYG cleaning credentials with BYOS

- Add service value to the list for removing credentials,
  this works because the service value is the name of the
  credential file in PAYG and BYOS