### PR TITLE
Handle update server cert change

### DIFF
--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2021 SUSE Software Solutions Germany GmbH. All rights reserved.
+# Copyright (c) 2022 SUSE Software Solutions Germany GmbH. All rights reserved.
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -12,6 +12,7 @@
 # License along with this library.
 
 import inspect
+import glob
 import os
 import sys
 
@@ -19,22 +20,172 @@ test_path = os.path.abspath(
     os.path.dirname(inspect.getfile(inspect.currentframe())))
 code_path = os.path.abspath('%s/../lib' % test_path)
 config_path = os.path.abspath('%s/../etc' % test_path)
+data_path = test_path + os.sep + 'data/'
 
 sys.path.insert(0, code_path)
 
-from cloudregister.registerutils import (
-    get_config,
-    is_registration_supported
-)
+import cloudregister.registerutils as utils
 
-cfg = get_config(config_path + '/regionserverclnt.cfg')
+from unittest.mock import patch
+from lxml import etree
+
+from cloudregister import smt
+
+
+cfg = utils.get_config(config_path + '/regionserverclnt.cfg')
+
+CACHE_SERVER_IPS = ['54.197.240.216', '54.225.105.144', '107.22.231.220']
+
+@patch('os.path.exists')
+def test_get_available_smt_servers_no_cache(path_exists):
+    path_exists.return_value = False
+    available_servers = utils.get_available_smt_servers()
+    assert [] == available_servers
+
+
+@patch('cloudregister.registerutils.get_state_dir')
+def test_get_available_smt_servers_cache(state_dir):
+    state_dir.return_value = data_path
+    available_servers = utils.get_available_smt_servers()
+    assert len(available_servers) == 3
+    for srv in available_servers:
+        assert srv.get_ipv4() in CACHE_SERVER_IPS
+
+
+def test_get_credentials_no_file():
+    user, passwd = utils.get_credentials(data_path + 'foo')
+    assert user == None
+    assert passwd == None
+
+
+def test_get_credentials():
+    user, passwd = utils.get_credentials(data_path + 'credentials')
+    assert user == 'SCC_1'
+    assert passwd == 'a23'
+
+
+def test_get_state_dir():
+    state_dir = utils.get_state_dir()
+    assert state_dir == '/var/cache/cloudregister/'
+
+
+@patch('cloudregister.registerutils.get_state_dir')
+def test_get_zypper_pid_cache_has_cache(state_dir):
+    state_dir.return_value = data_path
+    assert utils.get_zypper_pid_cache() == '28989'
+
+
+@patch('os.path.exists')
+def test_get_zypper_pid_cache_no_cache(path_exists):
+    path_exists.return_value = False
+    assert utils.get_zypper_pid_cache() == 0
 
 
 def test_is_registration_supported_SUSE_Family():
     cfg.set('service', 'packageBackend', 'zypper')
-    assert is_registration_supported(cfg) is True
+    assert utils.is_registration_supported(cfg) is True
 
 
 def test_is_registration_supported_RHEL_Family():
     cfg.set('service', 'packageBackend', 'dnf')
-    assert is_registration_supported(cfg) is False
+    assert utils.is_registration_supported(cfg) is False
+
+
+@patch('cloudregister.registerutils.is_new_registration')
+def test_update_rmt_certs_new_reg(new_reg):
+    new_reg.return_value = True
+    res = utils.update_rmt_certs()
+    assert res == None
+
+
+@patch('cloudregister.registerutils.import_smt_cert')
+@patch('cloudregister.registerutils.get_config')
+@patch('cloudregister.registerutils.fetch_smt_data')
+@patch('cloudregister.registerutils.set_proxy')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.is_new_registration')
+def test_update_rmt_certs_no_cert_change(
+        new_reg, state_dir, set_proxy, fetch_srvs, get_config, import_cert
+):
+    new_reg.return_value = False
+    state_dir.return_value = data_path
+    set_proxy.return_value = False
+    fetch_srvs.return_value = get_servers_data()
+    get_config.return_value = {}
+    utils.update_rmt_certs()
+    assert not import_cert.called
+
+
+@patch('cloudregister.registerutils.__populate_srv_cache')
+@patch('cloudregister.registerutils.clean_smt_cache')
+@patch('cloudregister.registerutils.import_smt_cert')
+@patch('cloudregister.registerutils.get_config')
+@patch('cloudregister.registerutils.fetch_smt_data')
+@patch('cloudregister.registerutils.set_proxy')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.is_new_registration')
+def test_update_rmt_certs_cert_change(
+        new_reg, state_dir, set_proxy, fetch_srvs, get_config, import_cert,
+        cache_clean, pop_cache
+):
+    new_reg.return_value = False
+    state_dir.return_value = data_path
+    set_proxy.return_value = False
+    fetch_srvs.return_value = get_modified_servers_data()
+    get_config.return_value = {}
+    utils.update_rmt_certs()
+    assert import_cert.called
+    assert cache_clean.called
+    assert pop_cache.called
+
+    
+#---------------------------------------------------------------------------
+# Helper functions
+
+def get_servers_data():
+    """The XML data matching the data pickled server objects"""
+    srv_xml = """<regionSMTdata>\n
+        <smtInfo
+            SMTserverIP="107.22.231.220"
+            SMTserverName="smt-ec2.susecloud.net"
+            fingerprint=
+            "9E:B5:BD:DA:97:52:DA:55:F0:F2:5D:5C:64:60:D3:E0:5C:D4:FB:79"/>\n
+        <smtInfo
+            SMTserverIP="54.197.240.216"
+            SMTserverName="smt-ec2.susecloud.net"
+            fingerprint=
+            "9E:B5:BD:DA:97:52:DA:55:F0:F2:5D:5C:64:60:D3:E0:5C:D4:FB:79"/>\n
+        <smtInfo
+            SMTserverIP="54.225.105.144"
+            SMTserverName="smt-ec2.susecloud.net"
+            fingerprint=
+            "9E:B5:BD:DA:97:52:DA:55:F0:F2:5D:5C:64:60:D3:E0:5C:D4:FB:79"/>\n
+    </regionSMTdata>
+    """
+
+    return etree.fromstring(srv_xml)
+
+
+def get_modified_servers_data():
+    """The XML with 1 server different than the data pickled server objects"""
+    srv_xml = """<regionSMTdata>\n
+        <smtInfo
+            SMTserverIP="107.22.231.220"
+            SMTserverName="smt-ec2.susecloud.net"
+            fingerprint=
+            "99:88:77:66"/>\n
+        <smtInfo
+            SMTserverIP="54.197.240.216"
+            SMTserverName="smt-ec2.susecloud.net"
+            fingerprint=
+            "9E:B5:BD:DA:97:52:DA:55:F0:F2:5D:5C:64:60:D3:E0:5C:D4:FB:79"/>\n
+        <smtInfo
+            SMTserverIP="54.225.105.144"
+            SMTserverName="smt-ec2.susecloud.net"
+            fingerprint=
+            "9E:B5:BD:DA:97:52:DA:55:F0:F2:5D:5C:64:60:D3:E0:5C:D4:FB:79"/>\n
+    </regionSMTdata>
+    """
+
+    return etree.fromstring(srv_xml)
+    

--- a/usr/lib/zypp/plugins/urlresolver/susecloud
+++ b/usr/lib/zypp/plugins/urlresolver/susecloud
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 
-# Copyright (c) 2019, SUSE LLC, All rights reserved.
+# Copyright (c) 2022, SUSE LLC, All rights reserved.
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -39,6 +39,16 @@ class SUSECloudPlugin(Plugin):
         repo_credentials = headers.get('credentials')
         if zypper_pid != prev_zypper_pid:
             verify_credentials = True
+            # The check for the certs is overkill, but for BYOS the
+            # registration service is not enabled by default, thus pushing
+            # the check to every reboot would mizz BYOS instances that
+            # use the update infrastructure as proxy to SCC.
+            # The other option would be to have another service that runs
+            # less frequently, once every 6 months for example.
+            # Given that updates via zypper are expected to be relatively
+            # infrequent on production systems we should be OK with the
+            # check here.
+            utils.update_rmt_certs()
         # Note this logic breaks when FATE#320882/PM-1251 gets implemented
         if (
                 verify_credentials and not


### PR DESCRIPTION
- At present when an update server has a cert change the client will fail and the user has to force a re-registration in order to get the new cert onto the client system. This change makes the import of the new cert automatic. A cert check is run every time zypper is executed.
- Improve test coverage of the utils code