### PR TITLE
Fix 'eqivalent' typo

### DIFF
--- a/tests/test_smt.py
+++ b/tests/test_smt.py
@@ -192,7 +192,7 @@ def test_get_ipv6_null():
 
 
 # ----------------------------------------------------------------------------
-def test_is_eqivalent():
+def test_is_equivalent():
     """Test two SMT servers with same name and fingerprint are treated
         as equivalent"""
     smt1 = SMT(etree.fromstring(smt_data_ipv4))
@@ -201,7 +201,7 @@ def test_is_eqivalent():
 
 
 # ----------------------------------------------------------------------------
-def test_is_eqivalent_fails():
+def test_is_equivalent_fails():
     """Test two SMT servers with same name but different fingerprint are
        treated as not equivalent"""
     smt1 = SMT(etree.fromstring(smt_data_ipv4))

--- a/usr/lib/zypp/plugins/urlresolver/susecloud
+++ b/usr/lib/zypp/plugins/urlresolver/susecloud
@@ -46,7 +46,7 @@ class SUSECloudPlugin(Plugin):
         ):
             self.error(
                 {'CREDENTIAL_ERROR': 'INCONSISTENT'},
-                'Not all credentials files are eqivalent: %s' % repo_credentials
+                'Not all credentials files are equivalent: %s' % repo_credentials
             )
             return
         server_name = ''


### PR DESCRIPTION
Replace eqivalent with equivalent.