### PR TITLE
Removes unused imports and other flake8 errors

### DIFF
--- a/lib/cloudregister/msftazure.py
+++ b/lib/cloudregister/msftazure.py
@@ -16,12 +16,10 @@ import html
 import logging
 import requests
 import re
-import time
 import urllib.request
 import urllib.parse
 import urllib.error
 
-from html.parser import HTMLParser
 
 extensionConfigRx = re.compile(
     r'.*<ExtensionsConfig>(.*?)</ExtensionsConfig>.*', re.S | re.M

--- a/tests/test_azureplugin.py
+++ b/tests/test_azureplugin.py
@@ -12,9 +12,7 @@
 # License along with this library.
 
 import inspect
-import logging
 import os
-import pytest
 import requests
 import sys
 
@@ -48,7 +46,7 @@ def test_metadata_request_fail(mock_logging, mock_request, mock_resolver):
     mock_request.side_effect = requests.exceptions.RequestException
     mock_resolver.return_value = _get_no_nameservers_resolver()
     result = azure.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     expected = 'Unable to determine instance placement from metadata '
     expected += 'server "http://169.254.169.254/metadata/'
@@ -64,7 +62,7 @@ def test_metadata_request_fail_server_error(mock_logging, mock_request):
     """Test metadata server error code return"""
     mock_request.return_value = _get_error_response()
     result = azure.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     expected = 'Unable to get availability zone metadata'
     actual = _get_msg(mock_logging.warning.call_args_list[0])
@@ -91,7 +89,6 @@ def test_metadata_request_success(mock_request):
     assert result == 'regionHint=useast'
 
 
-
 # ----------------------------------------------------------------------------
 @patch('msftazure.dns.resolver.get_default_resolver')
 @patch('msftazure.requests.get')
@@ -105,7 +102,7 @@ def test_wire_request_goal_state_request_fail(
     mock_request.side_effect = [None, requests.exceptions.RequestException]
     mock_resolver.return_value = _get_nameserver_resolver()
     result = azure.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     expected = 'Could not retrieve goal state XML from 1.1.1.1'
     actual = _get_msg(mock_logging.warning.call_args_list[0])
@@ -125,7 +122,7 @@ def test_wire_request_goal_state_request_fail_server_error(
     mock_request.side_effect = [None, _get_error_response()]
     mock_resolver.return_value = _get_nameserver_resolver()
     result = azure.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     expected = '1.1.1.1 error for goal state request: 500'
     actual = _get_msg(mock_logging.warning.call_args_list[0])
@@ -145,7 +142,7 @@ def test_wire_request_goal_state_request_success_no_match(
     mock_request.side_effect = [None, _get_unexpected_response()]
     mock_resolver.return_value = _get_nameserver_resolver()
     result = azure.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     expected = 'No "<ExtensionsConfig>" in goal state XML'
     actual = _get_msg(mock_logging.warning.call_args_list[0])
@@ -169,7 +166,7 @@ def test_wire_request_extension_request_fail(
     ]
     mock_resolver.return_value = _get_nameserver_resolver()
     result = azure.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     expected = 'Could not get extensions information from "'
     expected += 'http://ola%sdme&?getit=1"'
@@ -194,7 +191,7 @@ def test_wire_request_extension_request_fail_server_error(
     ]
     mock_resolver.return_value = _get_nameserver_resolver()
     result = azure.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     expected = 'Extensions request failed with: 500'
     actual = _get_msg(mock_logging.warning.call_args_list[0])
@@ -218,7 +215,7 @@ def test_wire_request_extension_request_success_no_match(
     ]
     mock_resolver.return_value = _get_nameserver_resolver()
     result = azure.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     expected = 'No "<Location>" in extensions XML'
     actual = _get_msg(mock_logging.warning.call_args_list[0])
@@ -252,7 +249,6 @@ def test_wire_request_success(mock_logging, mock_request, mock_resolver):
     assert result == 'regionHint=useast'
 
 
-
 # ----------------------------------------------------------------------------
 def _get_error_response():
     """Return an error code as the response of the request"""
@@ -263,7 +259,7 @@ def _get_error_response():
 
 
 # ----------------------------------------------------------------------------
-def _get_expected_response_metadata(upper = False):
+def _get_expected_response_metadata(upper=False):
     """Return an object mocking a expected response"""
     response = Response()
     response.status_code = 200
@@ -298,7 +294,7 @@ def _get_no_nameservers_resolver():
 
 
 # ----------------------------------------------------------------------------
-def _get_proper_extensions_response(upper = False):
+def _get_proper_extensions_response(upper=False):
     """Return a response that matches extensions config"""
     response = Response()
     region = 'useast'
@@ -327,7 +323,7 @@ def _get_proper_goal_state_response():
 
 # ----------------------------------------------------------------------------
 def _get_unexpected_response():
-    """Return an unexpected response, i.e. trigget a parse error"""
+    """Return an unexpected response, i.e. triggers a parse error"""
     response = Response()
     response.status_code = 200
     response.text = 'This matches nothing'

--- a/tests/test_ec2plugin.py
+++ b/tests/test_ec2plugin.py
@@ -12,9 +12,7 @@
 # License along with this library.
 
 import inspect
-import logging
 import os
-import pytest
 import requests
 import sys
 
@@ -43,7 +41,7 @@ def test_request_fail(mock_logging, mock_request_get, mock_request_put):
     mock_request_get.side_effect = requests.exceptions.RequestException
     mock_request_put.side_effect = requests.exceptions.RequestException
     result = ec2.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     msg = 'Unable to determine instance placement from "'
     msg += 'http://169.254.169.254/latest/meta-data/placement/'
@@ -62,7 +60,7 @@ def test_request_fail_response_error(
     """Test unexpected return value"""
     mock_request_get.return_value = _get_error_response()
     result = ec2.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     msg = '\tMessage: Test server failure'
     mock_logging.warning.assert_called_with(msg)
@@ -98,7 +96,7 @@ def _get_expected_response():
 
 # ----------------------------------------------------------------------------
 def _get_unexpected_response():
-    """Return an unexpected response, i.e. trigget a parse error"""
+    """Return an unexpected response, i.e. triggers a parse error"""
     response = Response()
     response.status_code = 200
     response.text = ''

--- a/tests/test_gceplugin.py
+++ b/tests/test_gceplugin.py
@@ -12,9 +12,7 @@
 # License along with this library.
 
 import inspect
-import logging
 import os
-import pytest
 import requests
 import sys
 
@@ -41,7 +39,7 @@ def test_request_fail(mock_logging, mock_request):
     """Test proper exception handling when request to metadata server fails"""
     mock_request.side_effect = requests.exceptions.RequestException
     result = gce.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     msg = 'Unable to determine zone information from "'
     msg += 'http://169.254.169.254/computeMetadata/v1/instance/zone'
@@ -56,7 +54,7 @@ def test_request_fail_parse_response(mock_logging, mock_request):
     """Test unexpected return value"""
     mock_request.return_value = _get_unexpected_response()
     result = gce.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     msg = 'Unable to form region string from text: '
     msg += 'projects/284177885636/zones/us-central1'
@@ -70,7 +68,7 @@ def test_request_fail_response_error(mock_logging, mock_request):
     """Test unexpected return value"""
     mock_request.return_value = _get_error_response()
     result = gce.generateRegionSrvArgs()
-    assert result == None
+    assert result is None
     assert mock_logging.warning.called
     msg = '\tMessage: Test server failure'
     mock_logging.warning.assert_called_with(msg)
@@ -105,7 +103,7 @@ def _get_expected_response():
 
 # ----------------------------------------------------------------------------
 def _get_unexpected_response():
-    """Return an unexpected response, i.e. trigget a parse error"""
+    """Return an unexpected response, i.e. triggers a parse error"""
     response = Response()
     response.status_code = 200
     response.text = 'projects/284177885636/zones/us-central1'

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -12,9 +12,10 @@
 # License along with this library.
 
 import inspect
-import glob
 import os
 import sys
+from unittest.mock import patch
+from lxml import etree
 
 test_path = os.path.abspath(
     os.path.dirname(inspect.getfile(inspect.currentframe())))
@@ -26,15 +27,11 @@ sys.path.insert(0, code_path)
 
 import cloudregister.registerutils as utils
 
-from unittest.mock import patch
-from lxml import etree
-
-from cloudregister import smt
-
 
 cfg = utils.get_config(config_path + '/regionserverclnt.cfg')
 
 CACHE_SERVER_IPS = ['54.197.240.216', '54.225.105.144', '107.22.231.220']
+
 
 @patch('os.path.exists')
 def test_get_available_smt_servers_no_cache(path_exists):
@@ -54,8 +51,8 @@ def test_get_available_smt_servers_cache(state_dir):
 
 def test_get_credentials_no_file():
     user, passwd = utils.get_credentials(data_path + 'foo')
-    assert user == None
-    assert passwd == None
+    assert user is None
+    assert passwd is None
 
 
 def test_get_credentials():
@@ -95,7 +92,7 @@ def test_is_registration_supported_RHEL_Family():
 def test_update_rmt_certs_new_reg(new_reg):
     new_reg.return_value = True
     res = utils.update_rmt_certs()
-    assert res == None
+    assert res is None
 
 
 @patch('cloudregister.registerutils.import_smt_cert')
@@ -138,8 +135,8 @@ def test_update_rmt_certs_cert_change(
     assert cache_clean.called
     assert pop_cache.called
 
-    
-#---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
 # Helper functions
 
 def get_servers_data():
@@ -188,4 +185,3 @@ def get_modified_servers_data():
     """
 
     return etree.fromstring(srv_xml)
-    


### PR DESCRIPTION
Pending PR to remove some unused imports and remove some pending flake8 issues.

After this PR is merged, the only errors for flake8 are:

```
flake8 tests/ lib/
tests/test_azureplugin.py:27:1: E402 module level import not at top of file
tests/test_ec2plugin.py:27:1: E402 module level import not at top of file
tests/test_gceplugin.py:27:1: E402 module level import not at top of file
tests/test_registerutils.py:28:1: E402 module level import not at top of file
tests/test_smt.py:28:1: E402 module level import not at top of file
lib/cloudregister/registerutils.py:544:22: W605 invalid escape sequence '\s'
lib/cloudregister/registerutils.py:545:22: W605 invalid escape sequence '\s'
lib/cloudregister/registerutils.py:546:20: W605 invalid escape sequence '\s'
lib/cloudregister/registerutils.py:546:24: W605 invalid escape sequence '\s'
```

Not sure if changing (in the test files with E402 error) the import for this own module before the path modification could have some impact...
```python
code_path = os.path.abspath('%s/../lib/cloudregister' % test_path)

sys.path.insert(0, code_path)

import msftazure as azure
```

I guess if we install the module with `python setup.py install -e` to run the tests we could use a regular import for the module and remove that hack? :thinking: 