### PR TITLE
Handle cert changes

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -917,7 +917,7 @@ def has_region_changed(cfg):
         region = region_hint.split('=')[-1]
 
     if framework == 'unknown' or region == 'unknown':
-        # We cannot determine with certainy if anything has changed
+        # We cannot determine with certainty if anything has changed
         # Assume everything is as it was
         return False
 
@@ -1363,6 +1363,9 @@ def update_rmt_cert(server):
             if region_rmt_server != server:
                 import_smt_cert(region_rmt_server)
                 return True
+
+    return False
+
 
 # ----------------------------------------------------------------------------
 def uses_rmt_as_scc_proxy():

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -350,6 +350,14 @@ def fetch_smt_data(cfg, proxies):
 
 
 # ----------------------------------------------------------------------------
+def finalize_registration():
+     """During registration we only write information about the update server
+        that is used for the registration to the cache. But we want to cache
+        information about all update servers."""
+     __populate_srv_cache()
+
+
+# ----------------------------------------------------------------------------
 def find_equivalent_smt_server(configured_smt, known_smt_servers):
     """Find an SMT server that is equivalent to the currently configured
        SMT server, only consider responsive servers"""
@@ -908,6 +916,11 @@ def has_region_changed(cfg):
         region_hint = __get_region_server_args(plugin)
         region = region_hint.split('=')[-1]
 
+    if framework == 'unknown' or region == 'unknown':
+        # We cannot determine with certainy if anything has changed
+        # Assume everything is as it was
+        return False
+
     try:
         registered_region = json.loads(
             open(get_framework_identifier_path()).read()
@@ -922,6 +935,19 @@ def has_region_changed(cfg):
         return False
 
     return True
+
+
+# ----------------------------------------------------------------------------
+def has_rmt_in_hosts(server):
+    """Check if an entry for the given update server is in the hosts file"""
+    hosts_content = open('/etc/hosts').read()
+    srv_ipv4 = server.get_ipv4()
+    srv_ipv6 = server.get_ipv6()
+
+    if srv_ipv4 in hosts_content or srv_ipv6 in hosts_content:
+        return True
+
+    return False
 
 
 # ----------------------------------------------------------------------------
@@ -1313,13 +1339,13 @@ def update_ca_chain(cmd_w_args_lst):
 
 
 # ----------------------------------------------------------------------------
-def update_rmt_certs():
-    """Check if the update server certs have changed and if yes update the
-       system accordingly"""
+def update_rmt_cert(server):
+    """Import the cert for the given server if it has changed"""
     # We are currently getting the latest cert information, nothing to do
     if is_new_registration():
         return
-    cached_rmt_servers = get_available_smt_servers()
+    target_ipv4 = server.get_ipv4()
+    target_ipv6 = server.get_ipv6()
     proxies = None
     if set_proxy():
         proxies = {
@@ -1330,28 +1356,13 @@ def update_rmt_certs():
     region_rmt_servers = []
     for child in region_rmt_server_data:
         region_rmt_servers.append(smt.SMT(child, True))
-    # We need to compare the unordered list of cached servers with the
-    # unordered list of servers we got from the region server.
-    # If any of the servers are different refresh the whole cache
-    # and import the new cert
     for region_rmt_server in region_rmt_servers:
         region_ipv4 = region_rmt_server.get_ipv4()
         region_ipv6 = region_rmt_server.get_ipv6()
-        for cached_rmt_server in cached_rmt_servers:
-            cached_ipv4 = cached_rmt_server.get_ipv4()
-            cached_ipv6 = cached_rmt_server.get_ipv6()
-            if (region_ipv4 == cached_ipv4) and (region_ipv6 == cached_ipv6):
-                if region_rmt_server == cached_rmt_server:
-                    break
-        else:
-            logging.info(
-                'Found updated update server information, importing new data'
-            )
-            import_smt_cert(region_rmt_server)
-            clean_smt_cache()
-            __populate_srv_cache()
-            return
-
+        if (region_ipv4 == target_ipv4) and (region_ipv6 == target_ipv6):
+            if region_rmt_server != server:
+                import_smt_cert(region_rmt_server)
+                return True
 
 # ----------------------------------------------------------------------------
 def uses_rmt_as_scc_proxy():

--- a/lib/cloudregister/smt.py
+++ b/lib/cloudregister/smt.py
@@ -35,7 +35,7 @@ class SMT:
             pass
         try:
             self._region = smtXMLNode.attrib['region']
-        except KeyError: 
+        except KeyError:
             self._region = 'unknown'
         self._fqdn = smtXMLNode.attrib['SMTserverName']
         self._fingerprint = smtXMLNode.attrib['fingerprint']

--- a/lib/cloudregister/smt.py
+++ b/lib/cloudregister/smt.py
@@ -33,6 +33,10 @@ class SMT:
             self._ipv6 = smtXMLNode.attrib['SMTserverIPv6']
         except KeyError:
             pass
+        try:
+            self._region = smtXMLNode.attrib['region']
+        except KeyError: 
+            self._region = 'unknown'
         self._fqdn = smtXMLNode.attrib['SMTserverName']
         self._fingerprint = smtXMLNode.attrib['fingerprint']
         self._cert = None
@@ -48,11 +52,16 @@ class SMT:
                 self.get_ipv4() == other_smt.get_ipv4() and
                 self.get_ipv6() == other_smt.get_ipv6() and
                 self.get_FQDN() == other_smt.get_FQDN() and
-                self.get_fingerprint() == other_smt.get_fingerprint()
+                self.get_fingerprint() == other_smt.get_fingerprint() and
+                self.get_region() == other_smt.get_region()
         ):
             return True
 
         return False
+
+    # --------------------------------------------------------------------
+    def __ne__(self, other_smt):
+        return not self.__eq__(other_smt)
 
     # --------------------------------------------------------------------
     def get_cert(self):
@@ -109,12 +118,19 @@ class SMT:
         return self._ipv6
 
     # --------------------------------------------------------------------
+    def get_region(self):
+        """Return the region name this server is associated with"""
+        return self._region
+
+    # --------------------------------------------------------------------
     def is_equivalent(self, smt_server):
-        """When 2 SMT servers have the same cert fingerprint and their
-           FQDN is the same they are equivalent."""
+        """Have both an ipv4 address and/or both an ipv6 address and they
+           are in the same region they are interchangable and considered
+           equivalent"""
         if (
-                self.get_FQDN() == smt_server.get_FQDN() and
-                self.get_fingerprint() == smt_server.get_fingerprint()
+                ((self.get_ipv4() and smt_server.get_ipv4()) or
+                 (self.get_ipv6() and smt_server.get_ipv6())) and
+                self.get_region() == smt_server.get_region()
         ):
             return True
 

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -165,8 +165,8 @@ def test_has_rmt_in_hosts_has_ipv4():
     """
     server = MockServer()
     with mock.patch('builtins.open', mock.mock_open(read_data=hosts_content)):
-        has_entry = utils.has_rmt_in_hosts(server) 
-    
+        has_entry = utils.has_rmt_in_hosts(server)
+
     assert True == has_entry
 
 
@@ -176,7 +176,7 @@ def test_has_rmt_in_hosts_has_ipv4_6():
     # in the test
 
     1.1.1.1   smt-foo.susecloud.net  smt-foo
-    11:22:33:44::::00   smt-foo.susecloud.net  smt-foo
+    11:22:33:44::00   smt-foo.susecloud.net  smt-foo
     """
     server = MockServer()
     with mock.patch('builtins.open', mock.mock_open(read_data=hosts_content)):
@@ -193,8 +193,8 @@ def test_has_rmt_in_hosts_ipv4_not_found():
     """
     server = MockServer()
     with mock.patch('builtins.open', mock.mock_open(read_data=hosts_content)):
-        has_entry = utils.has_rmt_in_hosts(server) 
-    
+        has_entry = utils.has_rmt_in_hosts(server)
+
     assert False == has_entry
 
 
@@ -202,12 +202,12 @@ def test_has_rmt_in_hosts_has_ipv6():
     hosts_content = """
     # simulates hosts file containing the ipv6 we are looking for in the test
 
-    11:22:33:44::::00   smt-foo.susecloud.net  smt-foo
+    11:22:33:44::00   smt-foo.susecloud.net  smt-foo
     """
     server = MockServer()
     with mock.patch('builtins.open', mock.mock_open(read_data=hosts_content)):
-        has_entry = utils.has_rmt_in_hosts(server) 
-    
+        has_entry = utils.has_rmt_in_hosts(server)
+
     assert True == has_entry
 
 
@@ -216,13 +216,13 @@ def test_has_rmt_in_hosts_has_ipv6_4():
     # simulates hosts file containing the ipv4 and iv6 we are looking for
     # in the test
 
-    11:22:33:44::::00   smt-foo.susecloud.net  smt-foo
+    11:22:33:44::00   smt-foo.susecloud.net  smt-foo
     1.1.1.1   smt-foo.susecloud.net  smt-foo
     """
     server = MockServer()
     with mock.patch('builtins.open', mock.mock_open(read_data=hosts_content)):
-        has_entry = utils.has_rmt_in_hosts(server) 
-    
+        has_entry = utils.has_rmt_in_hosts(server)
+
     assert True == has_entry
 
 
@@ -230,12 +230,12 @@ def test_has_rmt_in_hosts_ipv6_not_found():
     hosts_content = """
     # simulates hosts file containing the ipv6 we are looking for in the test
 
-    22:22:33:44::::00   smt-foo.susecloud.net  smt-foo
+    22:22:33:44::00   smt-foo.susecloud.net  smt-foo
     """
     server = MockServer()
     with mock.patch('builtins.open', mock.mock_open(read_data=hosts_content)):
-        has_entry = utils.has_rmt_in_hosts(server) 
-    
+        has_entry = utils.has_rmt_in_hosts(server)
+
     assert False == has_entry
 
 
@@ -294,4 +294,4 @@ class MockServer:
         return '1.1.1.1'
 
     def get_ipv6(self):
-        return '11:22:33:44::::00'
+        return '11:22:33:44::00'

--- a/usr/lib/zypp/plugins/urlresolver/susecloud
+++ b/usr/lib/zypp/plugins/urlresolver/susecloud
@@ -39,16 +39,6 @@ class SUSECloudPlugin(Plugin):
         repo_credentials = headers.get('credentials')
         if zypper_pid != prev_zypper_pid:
             verify_credentials = True
-            # The check for the certs is overkill, but for BYOS the
-            # registration service is not enabled by default, thus pushing
-            # the check to every reboot would mizz BYOS instances that
-            # use the update infrastructure as proxy to SCC.
-            # The other option would be to have another service that runs
-            # less frequently, once every 6 months for example.
-            # Given that updates via zypper are expected to be relatively
-            # infrequent on production systems we should be OK with the
-            # check here.
-            utils.update_rmt_certs()
         # Note this logic breaks when FATE#320882/PM-1251 gets implemented
         if (
                 verify_credentials and not
@@ -70,6 +60,22 @@ class SUSECloudPlugin(Plugin):
                 server_name = utils.get_update_server_name_from_hosts()
             else:
                 server_name = update_server.get_FQDN()
+                if verify_credentials:
+                    # The check for the cert on every zypper run is overkill.
+                    # However, for BYOS the registration service is not
+                    # enabled, thus pushing the check to every reboot would
+                    # miss BYOS instances that use the update infrastructure
+                    # as proxy to SCC. 
+                    # The other option would be to have another service that
+                    # runs less frequently, once every 6 months for example.
+                    # Given that updates via zypper are expected to be
+                    # relatively infrequent on production systems we should
+                    # be OK with the check here.
+                    if utils.update_rmt_cert(update_server):
+                        utils.set_as_current_smt(update_server)
+                        if not utils.has_rmt_in_hosts(update_server):
+                            utils.clean_hosts_file(server_name)
+                            utils.add_hosts_entry(update_server)
         if server_name:
             srv_url = 'https://%s' % server_name
             repo_url = srv_url + headers.get('path')

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -261,7 +261,7 @@ else:
 registration_smt = utils.get_current_smt()
 
 # Check if we are in the same region
-region_smt_servers = []
+region_smt_servers = cached_smt_servers
 region_change = utils.has_region_changed(cfg)
 if region_change and utils.uses_rmt_as_scc_proxy():
     # We do not have the users registration code, stay connected to the
@@ -269,51 +269,57 @@ if region_change and utils.uses_rmt_as_scc_proxy():
     # If the user also moved to a new framework registration will be broken
     # due to the instance data.
     # This code is a safe guard in case a user enabled the service on a BYOS
-    # instance, which is not supposed to be the case.
-    logging.info('Region change detected:')
-    logging.info('\tSystem uses SCC credentials, please re-register the system'
+    # instance, which is not supposed to be the case or tries
+    print('Region change detected:')
+    print('\tSystem uses SCC credentials, please re-register the system'
                  ' to the update infrastrusture in this region\n'
                  '\tregistercloudguest --clean\n'
                  '\tregistercloudguest -r YOUR_REG_CODE')
-    region_smt_servers = cached_smt_servers
 elif region_change:
     logging.info('Region change detected, registering to new servers')
     cleanup()
-    cached_smt_servers = []
+    region_smt_servers = cached_smt_servers = []
     registration_smt = None
     utils.set_new_registration_flag()
     utils.write_framework_identifier(cfg)
+
+if not region_smt_servers:
     for child in region_smt_data:
         smt_server = smt.SMT(child, utils.https_only(cfg))
-        region_smt_servers.append(smt)
+        region_smt_servers.append(smt_server)
 
-# Check if the target SMT for the registration is alive or if we can
+# Check if the target RMT for the registration is alive or if we can
 # find a server that is alive in this region
 if registration_smt:
     registration_smt_cache_file_name = (
             utils.get_state_dir() +
             utils.REGISTERED_SMT_SERVER_DATA_FILE_NAME
         )
+    updated = utils.update_rmt_cert(registration_smt)
     alive = registration_smt.is_responsive()
     if alive:
         msg = 'Instance is registered, and update server is reachable, '
         msg += 'nothing to do'
         # The cache data may have been cleared, write if necessary
-        if not os.path.exists(registration_smt_cache_file_name):
+        if not os.path.exists(registration_smt_cache_file_name) or updated:
             utils.store_smt_data(
                 registration_smt_cache_file_name,
                 registration_smt
             )
+            if not utils.has_rmt_in_hosts(registration_smt):
+                utils.clean_hosts_file(registration_smt.get_FQDN())
+                utils.add_hosts_entry(registration_smt)
         logging.info(msg)
         sys.exit(0)
     else:
-        # The configured server is not resposive, lets check if we can
+        # The current target server is not resposive, lets check if we can
         # find another server
-        new_target = utils.find_equivalent_smt_server(
-            registration_smt,
-            region_smt_servers
-        )
-        if new_target:
+        for new_target in region_smt_servers:
+            if (
+                    not new_target.is_responsive() or
+                    not registration_smt.is_equivalent()
+            ):
+                continue
             smt_ip = new_target.get_ipv4()
             if utils.has_ipv6_access(new_target):
                 smt_ip = new_target.get_ipv6()
@@ -322,14 +328,23 @@ if registration_smt:
             utils.replace_hosts_entry(registration_smt, new_target)
             utils.store_smt_data(
                 registration_smt_cache_file_name,
-                registration_smt
+                new_target
             )
+            utils.update_rmt_cert(new_target)
+            break
         else:
             msg = 'Configured update server is unresponsive. Could not find '
             msg += 'a replacement update server in this region. '
             msg += 'Possible network configuration issue'
             logging.error(msg)
             sys.exit(1)
+
+# We should not get here for a registered system that is a proxy. However,
+# it doesn't hurt to check and get out before breaking things
+if utils.uses_rmt_as_scc_proxy():
+    logging.info('System already uses the update infrastructure with a '
+                 'registration code, nothing to do')
+    sys.exit(0)
 
 # Figure out which server is responsive and use it as registration target
 registration_target = None
@@ -482,6 +497,7 @@ if registration_returncode != 0:
         file=sys.stderr
     )
 else:
+    utils.finalize_registration()
     print('Registration succeeded')
 
 if os.path.exists(instance_data_filepath):

--- a/usr/sbin/updatesmtcache
+++ b/usr/sbin/updatesmtcache
@@ -32,12 +32,26 @@ if os.path.exists(utils.OLD_REGISTRATION_DATA_DIR):
         )
     )
 
+# Update the server cache with region information introduced in
+# region server 8.1.3
 cached_server_files = glob.glob('%s/*SMT*' % utils.REGISTRATION_DATA_DIR)
+proxies = None
+    if set_proxy():
+        proxies = {
+            'http_proxy': os.environ.get('http_proxy'),
+            'https_proxy': os.environ.get('https_proxy')
+        }
+cfg = utils.get_config()
+region_rmt_data = utils.fetch_smt_data(cfg, proxies)
+region_rmt_servers = []
+for child in region_rmt_data:
+    smt_server = smt.SMT(child, utils.https_only(cfg))
+    region_rmt_servers.append(smt)
 
 for cached_server_file in cached_server_files:
-    smt = utils.get_smt_from_store(cached_server_file)
-    if hasattr(smt, 'set_protocol'):
-        smt.set_protocol('http')
-        if utils.https_only(utils.get_config()):
-            smt.set_protocol('https')
-    utils.store_smt_data(cached_server_file, smt)
+    rmt = utils.get_smt_from_store(cached_server_file)
+    cached_ipv4 = rmt.get_ipv4()
+    for region_rmt in region_rmt_servers:
+        if region_rmt.get_ipv4() == cached_ipv4:
+            utils.store_smt_data(cached_server_file, region_rmt)
+            break


### PR DESCRIPTION
Detect if the cert of the current target update server has changed. If it has update the client system by importing the new cert. Also check the hosts entry and update if necessary.