### PR TITLE
Add system UUID info to instance data

### DIFF
--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -16,7 +16,7 @@
 #
 
 
-%define base_version 10.0.8
+%define base_version 10.1.0
 Name:           cloud-regionsrv-client
 Version:        %{base_version}
 Release:        0

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -622,6 +622,8 @@ def get_instance_data(config):
     # Marker for the server to not return https:// formatted
     # service and repo information
     instance_data += '<repoformat>plugin:susecloud</repoformat>\n'
+    # add system UUID to use as an ID instead of system_token
+    instance_data += '<uuid>{}</uuid>\n'.format(_get_instance_uuid())
 
     return instance_data
 
@@ -1621,3 +1623,19 @@ def __replace_url_target(config_files, new_smt):
                 current_service_server,
                 new_smt.get_FQDN()))
             new_config.close()
+
+# ----------------------------------------------------------------------------
+def _get_instance_uuid():
+    """Return the system UUID information."""
+    try:
+        uuid, error = exec_subprocess(
+            ['dmidecode', '-s', 'system-uuid'], True
+        )
+        if error:
+            logging.error(error)
+            uuid = b'unknown'
+    except Exception as error:
+        logging.error(error)
+        uuid = b'unknown'
+
+    return uuid.decode().strip()

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -508,6 +508,16 @@ def get_modified_servers_data():
 
     return etree.fromstring(srv_xml)
 
+@patch('cloudregister.registerutils.exec_subprocess')
+def test_get_uuid(subproc):
+    subproc.return_value = (b'foo', b'')
+    assert 'foo' == utils._get_instance_uuid()
+
+@patch('cloudregister.registerutils.exec_subprocess')
+def test_get_uuid_error(subproc):
+    subproc.return_value = (b'foo', b'OH NO')
+    assert 'unknown' == utils._get_instance_uuid()
+
 
 class MockServer:
     def get_ipv4(self):


### PR DESCRIPTION
Send system UUID in the metadata
to use as the system identifier
instead of system_token