### PR TITLE
Remove from SCC when cleaning up

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -1261,7 +1261,7 @@ def remove_registration_data():
         clean_hosts_file(domain_name)
         __remove_repo_artifacts(server_name)
         os.unlink(smt_data_file)
-    elif is_scc_connected():
+    if is_scc_connected():
         logging.info('Removing system from SCC')
         try:
             response = requests.delete(


### PR DESCRIPTION
Before systems registered either to SCC
or RMT infrastructure, now there can be
cases where the cleaning up needs to
happen for both type of repositories