### PR TITLE
Do not warn about system_token entry

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -484,13 +484,13 @@ def get_credentials(credentials_file):
         return (username, password)
     with open(credentials_file) as cred_file:
         credentials = cred_file.readlines()
-    known_entries = ['system_token']
+    known_entries = ('system_token')
     for entry in credentials:
         if entry.startswith('username'):
             username = entry.split('=')[-1].strip()
         elif entry.startswith('password'):
             password = entry.split('=')[-1].strip()
-        elif entry not in known_entries:
+        elif not entry.startswith(known_entries):
             logging.warning('Found unknown entry in '
                             'credentials file "%s"' % entry)
 

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -484,12 +484,13 @@ def get_credentials(credentials_file):
         return (username, password)
     with open(credentials_file) as cred_file:
         credentials = cred_file.readlines()
+    known_entries = ['system_token']
     for entry in credentials:
         if entry.startswith('username'):
             username = entry.split('=')[-1].strip()
         elif entry.startswith('password'):
             password = entry.split('=')[-1].strip()
-        else:
+        elif entry not in known_entries:
             logging.warning('Found unknown entry in '
                             'credentials file "%s"' % entry)
 


### PR DESCRIPTION
-- SCC uses system_token for duplicate systems 
  and as such, SCC writes the system_token value 
  in the credentials file, versions newer than 0.3.36 
  will not write the system_token 
  Regardless, cloud-regionsrv-client only checks 
  username and password in the credentials file so, 
  code ignores (does not show a warning) if system_token 
  entry is present