### PR TITLE
Prep for container use

### DIFF
--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -56,6 +56,7 @@ BuildRequires:  python3-lxml
 BuildRequires:  python3-requests
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-zypp-plugin
+BuildRequires:  systemd-rpm-macros
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 BuildArch:      noarch

--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -45,7 +45,11 @@ Requires:       regionsrv-certs
 Requires:       zypper
 BuildRequires:  systemd
 Conflicts:      container-suseconnect
+%if 0%{?suse_version} == 1315
 %{?systemd_requires}
+%else
+%{?systemd_ordering}
+%endif
 BuildRequires:  python-rpm-macros
 BuildRequires:  python3-M2Crypto
 BuildRequires:  python3-lxml


### PR DESCRIPTION
This is the start of being able to use cloud-regionsrv-client from a container. Inside a container we do not want systemd and it's dependencies. Change the macro used such that systemd is not automatically set up as package dependency on SLE 15 and later distributions.