### PR TITLE
Report error when registration failed

### DIFF
--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -541,7 +541,7 @@ if registration_returncode != 0:
         'Registration failed, see /var/log/cloudregister for details',
         file=sys.stderr
     )
-    sys.exit(1)
+    sys.exit(registration_returncode)
 
 print('Registration succeeded')
 

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -559,7 +559,6 @@ if registration_returncode != 0:
     )
     sys.exit(registration_returncode)
 
-
 print('Registration succeeded')
 
 if failed_extensions:
@@ -574,7 +573,6 @@ if failed_extensions:
 
 if os.path.exists(instance_data_filepath):
     os.unlink(instance_data_filepath)
-
 
 # Enable Nvidia repo if repo(s) are configured and destination can be reached
 if utils.has_nvidia_support():

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -531,17 +531,19 @@ prod_data = json.loads(res.text)
 extensions = prod_data.get('extensions')
 register_modules(extensions, products)
 
+
+if os.path.exists(instance_data_filepath):
+    os.unlink(instance_data_filepath)
+
 if registration_returncode != 0:
     cleanup()
     print(
         'Registration failed, see /var/log/cloudregister for details',
         file=sys.stderr
     )
-else:
-    print('Registration succeeded')
+    sys.exit(1)
 
-if os.path.exists(instance_data_filepath):
-    os.unlink(instance_data_filepath)
+print('Registration succeeded')
 
 # Enable Nvidia repo if repo(s) are configured and destination can be reached
 if utils.has_nvidia_support():


### PR DESCRIPTION
Currently, if registration failed, the command registercloudguest would return 0 as its return code on some scenarios 

This PR should fix that
Remove cache file before informing if registration failed (and exit) or not