### PR TITLE
Unhandeled Exception with IPv4 only client with IPv6 update server config

### DIFF
--- a/lib/cloudregister/smt.py
+++ b/lib/cloudregister/smt.py
@@ -19,7 +19,6 @@ import logging
 import requests
 import os
 
-from urllib.parse import urlparse
 from M2Crypto import X509
 
 
@@ -189,30 +188,31 @@ class SMT:
     def write_cert(self, target_dir):
         """Write the certificate to the given directory"""
         logging.info('Writing SMT rootCA: %s' % target_dir)
-        cert_id = 1
+        cert = self.get_cert()
+        certs_to_write = []
         ipv4 = self.get_ipv4()
         if ipv4:
-            cert_id = ipv4.replace('.', '_')
-        if cert_id != 1:
-            ipv6 = self.get_ipv6()
-            if ipv6:
-                cert_id = ipv6.replace(':', '_')
-        ca_file_path = os.path.join(
-            target_dir,
-            'registration_server_%s.pem' % cert_id
-        )
-        try:
-            with open(ca_file_path, 'w') as smt_ca_file:
-                smt_ca_file.write(self.get_cert())
-        except IOError:
-            errMsg = 'Could not store SMT certificate'
-            logging.error(errMsg)
-            return 0
-        except TypeError as err:
-            logging.error(str(err))
-            return 0
+            certs_to_write.append(ipv4.replace('.', '_'))
+        ipv6 = self.get_ipv6()
+        if ipv6:
+            certs_to_write.append(ipv6.replace(':', '_'))
+        ca_file_path = os.path.join(target_dir, 'registration_server_%s.pem')
+        # We write the cert twice one time with the IPv4 as identifier and
+        # one time with the IPv6 as identifier. This is not an indication that
+        # the update server can be reached over both protocols.
+        # Changing the naming convention to something generic so we could
+        # write the cert only once would break SUMa as it looks for the certs
+        # we write here with the known pattern.
+        for cert_name in certs_to_write:
+            try:
+                with open(ca_file_path %cert_name, 'w') as smt_ca_file:
+                    smt_ca_file.write(cert)
+            except IOError:
+                errMsg = 'Could not store update server certificate'
+                logging.error(errMsg)
+                return 0
 
-        return ca_file_path
+        return 1
 
     # Private
     # --------------------------------------------------------------------
@@ -232,9 +232,10 @@ class SMT:
             check_urls[health_url] = cert_url
 
         return check_urls
-
+ 
+    # --------------------------------------------------------------------
     def __is_cert_valid(self, cert):
-        """Verfify that the fingerprint of the given cert matches the
+        """Verify that the fingerprint of the given cert matches the
            expected fingerprint"""
         try:
             x509 = X509.load_cert_string(str(cert))
@@ -259,7 +260,6 @@ class SMT:
         retries = 3
         while attempts < retries:
             attempts += 1
-            print('eeee')
             for cert_name in self._cert_names:
                 for cert_url in self._check_urls.values():
                     try:
@@ -268,14 +268,13 @@ class SMT:
                             )
                     except Exception:
                         # No response from server
-                        logging.error('=' * 20)
-                        logging.error(
-                            'Attempt %s with %s of %s' % (
-                                attempts, cert_name, retries)
-                        )
-                        parsed_cert_url = urlparse(cert_url)
-                        logging.error(
-                            'Server %s is unreachable' % parsed_cert_url.netloc
-                        )
+                        logging.warning('+' * 20)
+                        # Extract the IP address we tried
+                        ip = 'unkown'
+                        if '[' in cert_url:
+                            ip = self.get_ipv6()
+                        else:
+                            ip = self.get_ipv4()
+                        logging.warning('Server %s is unreachable' % ip)
                     if cert_res and cert_res.status_code == 200:
                         return cert_res

--- a/tests/test_smt.py
+++ b/tests/test_smt.py
@@ -11,9 +11,11 @@
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
 
+import glob
 import inspect
 import os
 import sys
+import tempfile
 
 from lxml import etree
 from mock import patch, Mock
@@ -133,51 +135,29 @@ def test_get_cert_invalid_cert(mock_cert_pull, mock_logging):
 
 
 # ----------------------------------------------------------------------------
-@patch('smt.os.path.join')
 @patch('smt.logging')
 @patch('smt.requests.get')
-def test_write_cert_exception(
-    mock_request_get,
-    mock_logging,
-    mock_os_path_join
-):
-    """Handle exception when writing the cert and it failed fetching."""
+def test_get_cert_access_exception_ipv4(mock_request_get, mock_logging):
+    """Test the exception path for cert retrieval when we cannot reach
+       an update server with IPv4 adddress"""
     mock_request_get.side_effect = Exception('FOO')
-    smt = SMT(etree.fromstring(smt_data_ipv46))
-    mock_os_path_join.return_value = '/tmp/registration_server_fc00__1.pem'
+    smt = SMT(etree.fromstring(smt_data_ipv4))
     assert not smt.get_cert()
-    assert mock_logging.error.called
-    mock_logging.error.assert_called_with('Server 192.168.1.1 is unreachable')
-    assert not smt.write_cert('tmp')
-    os.remove('/tmp/registration_server_fc00__1.pem')
-    msg = 'write() argument must be str, not None'
-    mock_logging.error.assert_called_with(msg)
+    mock_logging.warning.assert_called_with('Server 192.168.1.1 is unreachable')
 
 
 # ----------------------------------------------------------------------------
-@patch.object(SMT, 'get_cert')
-@patch('smt.os.path.join')
 @patch('smt.logging')
 @patch('smt.requests.get')
-def test_write_cert(
-    mock_request_get,
-    mock_logging,
-    mock_os_path_join,
-    mock_get_cert
-):
-    """Write the fetched cert."""
-    response = Response()
-    response.status_code = 200
-    response.text = 'Not a cert'
-    mock_request_get.return_value = response
-    smt = SMT(etree.fromstring(smt_data_ipv46))
-    mock_os_path_join.return_value = '/tmp/registration_server_fc00__1.pem'
-    mock_get_cert.return_value = 'what a cert'
-    assert smt.write_cert('tmp') == '/tmp/registration_server_fc00__1.pem'
-    os.remove('/tmp/registration_server_fc00__1.pem')
-    assert not mock_logging.called
-
-
+def test_get_cert_access_exception_ipv6(mock_request_get, mock_logging):
+    """Test the exception path for cert retrieval when we cannot reach
+       an update server with IPv6 adddress"""
+    mock_request_get.side_effect = Exception('FOO')
+    smt = SMT(etree.fromstring(smt_data_ipv6))
+    assert not smt.get_cert()
+    mock_logging.warning.assert_called_with('Server fc00::1 is unreachable')
+    
+    
 # ----------------------------------------------------------------------------
 @patch('smt.X509.load_cert_string')
 @patch('smt.logging')
@@ -272,7 +252,6 @@ def test_is_equivalent_on_ipv6():
     assert smt1.is_equivalent(smt2)
 
 
-
 # ----------------------------------------------------------------------------
 def test_is_equivalent_fails_differ_ipv():
     """Test two SMT servers with different network config are not equivalent"""
@@ -297,7 +276,6 @@ def test_is_equivalent_true_same():
     assert smt1.is_equivalent(smt2)
 
 
-    
 # ----------------------------------------------------------------------------
 @patch('smt.requests.get')
 def test_is_responsive_server_offline(mock_cert_pull):
@@ -317,6 +295,7 @@ def test_is_responsive_server_error(mock_cert_pull):
     mock_cert_pull.return_value = response
     smt = SMT(etree.fromstring(smt_data_ipv46))
     assert not smt.is_responsive()
+
 
 # ----------------------------------------------------------------------------
 def test_check_urls_ipv4():
@@ -346,3 +325,63 @@ def test_check_urls_ipv46():
     assert \
         smt._check_urls.get('https://[fc00::1]/api/health/status') == \
         'http://[fc00::1]/'
+
+
+# ----------------------------------------------------------------------------
+@patch.object(SMT, 'get_cert')
+def test_write_cert_ipv4_only(mock_get_cert):
+    """Check we write the cert for the IPv4 address if the update server
+       has an IPv4 only configuration"""
+    mock_get_cert.return_value = 'what a cert'
+    smt = SMT(etree.fromstring(smt_data_ipv4))
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        smt.write_cert(tmpdirname)
+        certs = glob.glob('%s/*.pem' %tmpdirname)
+        assert len(certs) == 1
+        assert certs[0] == '%s/registration_server_192_168_1_1.pem' %tmpdirname
+
+
+# ----------------------------------------------------------------------------
+@patch.object(SMT, 'get_cert')
+def test_write_cert_ipv6_only(mock_get_cert):
+    """Check we write the cert for the IPv6 address if the update server
+       has an IPv6 only configuration"""
+    mock_get_cert.return_value = 'what a cert'
+    smt = SMT(etree.fromstring(smt_data_ipv6))
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        smt.write_cert(tmpdirname)
+        certs = glob.glob('%s/*.pem' %tmpdirname)
+        assert len(certs) == 1
+        assert certs[0] == '%s/registration_server_fc00__1.pem' %tmpdirname
+
+
+# ----------------------------------------------------------------------------
+@patch.object(SMT, 'get_cert')
+def test_write_cert_dual_stack(mock_get_cert):
+    """Check we write the cert for the IPv4 and IPv6 address if the update
+       server has an IPv4 and IPv6 configuration"""
+    mock_get_cert.return_value = 'what a cert'
+    smt = SMT(etree.fromstring(smt_data_ipv46))
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        smt.write_cert(tmpdirname)
+        certs = glob.glob('%s/*.pem' %tmpdirname)
+        assert len(certs) == 2
+        assert '%s/registration_server_fc00__1.pem' %tmpdirname in certs
+        assert '%s/registration_server_192_168_1_1.pem' %tmpdirname in certs
+
+
+# ----------------------------------------------------------------------------
+@patch.object(SMT, 'get_cert')
+@patch('smt.logging')
+def test_write_cert_no_write_perm(mock_logging, mock_get_cert):
+    """Check that we properly handle the exception if we cannot write the
+       cert."""
+    mock_get_cert.return_value = 'what a cert'
+    smt = SMT(etree.fromstring(smt_data_ipv46))
+    result = smt.write_cert('fussball')
+    assert result == 0
+    mock_logging.error.assert_called_with(
+        'Could not store update server certificate'
+    )
+
+


### PR DESCRIPTION

When the region server returns an update server configuration with IPv4 and IPv6 but the client only has IPv4 capability an unhandeld exception is triggered due to an uninitialized variable.

Once the unitialized variable issue is fixed, the code will write the server cert to the trust anchors only with the IPv6 name as reference. This is confusing. The updated code writes the cert with botht the IPv4 and IPv6 names.

Add tests for the updates smt.py implementation.