### PR TITLE
Fix case when switching license from any not empty non SLES_BYOS to SLES_BYOS without cache file

### DIFF
--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -110,7 +110,7 @@ Requires:       python3-dnspython
 Guest registration plugin for images intended for Microsoft Azure
 
 %package addon-azure
-Version:	1.0.5
+Version:	1.0.6
 Release:	0
 Summary:	Enable/Disable Guest Registration for Microsoft Azure
 Group:		Productivity/Networking/Web/Servers

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -98,8 +98,10 @@ service_name = 'guestregister'
 license_type = get_license_type()
 
 if ('BYOS' in license_type and not utils.uses_rmt_as_scc_proxy()):
+    # Registered to SCC
     license_has_changed = has_license_changed(license_type)
     if license_has_changed in [False]:
+        # System is still BYOS, nothing to do
         sys.exit(0)
     if license_has_changed:
         update_license_cache(license_type)

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -37,6 +37,7 @@ def has_license_changed(license_type):
             return license_type != old_license
     except FileNotFoundError:
         update_license_cache(license_type)
+        raise
 
 
 def get_license_type():
@@ -97,20 +98,33 @@ utils.start_logging()
 service_name = 'guestregister'
 license_type = get_license_type()
 
-if ('BYOS' in license_type and has_license_changed(license_type) and
-    not utils.uses_rmt_as_scc_proxy()):
+if ('BYOS' in license_type and not utils.uses_rmt_as_scc_proxy()):
+    try:
+        if not has_license_changed(license_type):
+            sys.exit(0)
+        update_license_cache(license_type)
+    except FileNotFoundError:
+        # if cache file did not exist, it got created
+        # only thing left to do is to de-register
+        pass
     run_command(['registercloudguest', '--clean'])
     run_command(['systemctl', 'disable', service_name])
-    update_license_cache(license_type)
 elif license_type and 'BYOS' not in license_type:
     # if no license type, system could be a BYOS without AHB
     # or PAYG without AHB
     update_server = utils.get_smt()
     if update_server:
-        if (not has_license_changed(license_type) and
-            utils.is_registered(update_server.get_FQDN())):
-            sys.exit(0)
-        update_license_cache(license_type)
+        try:
+            license_has_changed = has_license_changed(license_type)
+            if (not license_has_changed and
+                utils.is_registered(update_server.get_FQDN())):
+                sys.exit(0)
+            if license_has_changed:
+                update_license_cache(license_type)
+        except FileNotFoundError:
+            # if cache file did not exit, it got created
+            # only thing left to do is to register
+            pass
         update_server = None
     if not update_server:
         run_command(['registercloudguest', '--force-new'])

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -154,15 +154,16 @@ elif license_type and 'BYOS' not in license_type:
         if (not license_has_changed and
             utils.is_registered(update_server.get_FQDN())):
             # covers cases 7, 15, 16, 17, 18
+            if utils.is_scc_connected():
+                # cover cases 11
+                run_command(['registercloudguest', '--force-new'])
+                run_command(['systemctl', 'enable', service_name])
             sys.exit(0)
-        if license_has_changed:
-            # cases 12
-            update_license_cache(license_type)
         update_server = None
     if not update_server:
-        # cover cases 1, 2, 8
+        # cover cases 1, 2, 8, 12
         if has_license_changed(license_type):
-            # cover cases 2, 8
+            # cover cases 2, 8, 12
             update_license_cache(license_type)
         run_command(['registercloudguest', '--force-new'])
         run_command(['systemctl', 'enable', service_name])

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -12,6 +12,21 @@
 # Lesser General Public License for more details.
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library.
+
+"""
+Check the different states of the license type:
+    START   LICENSE CHANGED TO     CACHE   ACTION
+    BYOS    SLES                   N/A     Register
+    BYOS    SLES                   BYOS    Register
+    BYOS    BYOS                   N/A     Do nothing
+    BYOS    BYOS                   BYOS    Do nothing
+
+    SLES    BYOS                   N/A     De-register
+    SLES    BYOS                   SLES    De-register
+    SLES    SLES                   N/A     Do nothing
+    SLES    SLES                   SLES    Do nothing
+"""
+
 import logging
 import os
 import requests
@@ -19,6 +34,7 @@ import subprocess
 import sys
 
 import cloudregister.registerutils as utils
+
 
 CACHE_LICENSE_PATH = os.path.join(utils.get_state_dir(), 'cached_license')
 

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -127,18 +127,20 @@ service_name = 'guestregister'
 license_type = get_license_type()
 update_server = utils.get_smt()
 
-if ('BYOS' in license_type and not utils.uses_rmt_as_scc_proxy()):
+if ('BYOS' in license_type and not utils.uses_rmt_as_scc_proxy() and
+    not utils.is_scc_connected()
+):
     license_has_changed = has_license_changed(license_type)
-    if (
-        license_has_changed or
+    if (license_has_changed or
         (update_server and utils.is_registered(update_server.get_FQDN()))
     ):
         # either license has changed or
-        # system was previously registered
+        # system was previously registered to update infrastructure
+        # and neither SCC nor RMT as an SCC proxy
         if license_has_changed:
             update_license_cache(license_type)
-    run_command(['registercloudguest', '--clean'])
-    run_command(['systemctl', 'disable', service_name])
+        run_command(['registercloudguest', '--clean'])
+        run_command(['systemctl', 'disable', service_name])
 elif license_type and 'BYOS' not in license_type:
     # if no license type, system could be a BYOS without AHB
     # or PAYG without AHB

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -100,7 +100,7 @@ license_type = get_license_type()
 if ('BYOS' in license_type and not utils.uses_rmt_as_scc_proxy()):
     # Registered to SCC
     license_has_changed = has_license_changed(license_type)
-    if license_has_changed in [False]:
+    if license_has_changed == False:
         # System is still BYOS, nothing to do
         sys.exit(0)
     if license_has_changed:
@@ -113,7 +113,7 @@ elif license_type and 'BYOS' not in license_type:
     update_server = utils.get_smt()
     if update_server:
         license_has_changed = has_license_changed(license_type)
-        if (license_has_changed in [False] and
+        if (license_has_changed == False and
             utils.is_registered(update_server.get_FQDN())):
             sys.exit(0)
         if license_has_changed:

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -16,28 +16,29 @@
 """
 Check the different states of the license type:
     START   LICENSE CHANGED TO     CACHE   ACTION
-    BYOS-1  SLES                   N/A     Register
-    BYOS-1  SLES                   BYOS    Register
-    BYOS-1  BYOS-1                 N/A     Do nothing
+    BYOS-1  SLES                   No      Register - Update Infra
+    BYOS-1  SLES                   BYOS    Register - Update Infra
+    BYOS-1  BYOS-1                 No      Do nothing
     BYOS-1  BYOS-1                 BYOS    Do nothing
-    BYOS-1  BYOS-2                 N/A     Do nothing
+    BYOS-1  BYOS-2                 No      Do nothing
     BYOS-1  BYOS-2                 BYOS    Do nothing
 
-    BYOS-2  SLES                   N/A     Do nothing
-    BYOS-2  SLES                   BYOS    Re-register
-    BYOS-2  BYOS-1                 N/A     De-register
-    BYOS-2  BYOS-1                 BYOS    De-register
+    BYOS-2  SLES                   No      Do nothing
+    BYOS-2  SLES                   BYOS    Re-register - Update Infra
+    BYOS-2  BYOS-1                 No      De-register - Update Infra
+    BYOS-2  BYOS-1                 BYOS    De-register - Update Infra
 
-    SLES    BYOS-1                 N/A     De-register
-    SLES    BYOS-1                 N/A     De-register
-    SLES    BYOS-2                 N/A     Do nothing
+    SLES    BYOS-1                 No      De-register - Update Infra
+    SLES    BYOS-1                 No      De-register - Update Infra
+    SLES    BYOS-2                 No      Do nothing
     SLES    BYOS-2                 SLES    Do nothing
-    SLES    SLES                   N/A     Do nothing
+    SLES    SLES                   No      Do nothing
     SLES    SLES                   SLES    Do nothing
 
 BYOS-1 -> BYOS unregistered
 BYOS-2 -> BYOS registered
 NOTE: When an instance starts the license_type value from IMDS is none (empty)
+START represents the state of the license type before running AHB
 """
 
 import logging

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -37,7 +37,7 @@ def has_license_changed(license_type):
             return license_type != old_license
     except FileNotFoundError:
         update_license_cache(license_type)
-
+        return False
 
 def get_license_type():
     proxies = {
@@ -96,21 +96,23 @@ def run_command(command):
 utils.start_logging()
 service_name = 'guestregister'
 license_type = get_license_type()
+update_server = utils.get_smt()
 
 if ('BYOS' in license_type and not utils.uses_rmt_as_scc_proxy()):
-    # Registered to SCC
     license_has_changed = has_license_changed(license_type)
-    if license_has_changed == False:
-        # System is still BYOS, nothing to do
-        sys.exit(0)
-    if license_has_changed:
-        update_license_cache(license_type)
+    if (
+        license_has_changed or
+        (update_server and utils.is_registered(update_server.get_FQDN()))
+    ):
+        # either license has changed or
+        # system was previously registered
+        if license_has_changed:
+            update_license_cache(license_type)
     run_command(['registercloudguest', '--clean'])
     run_command(['systemctl', 'disable', service_name])
 elif license_type and 'BYOS' not in license_type:
     # if no license type, system could be a BYOS without AHB
     # or PAYG without AHB
-    update_server = utils.get_smt()
     if update_server:
         license_has_changed = has_license_changed(license_type)
         if (license_has_changed == False and

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -15,30 +15,35 @@
 
 """
 Check the different states of the license type:
+START -> The state of the instance when this code is executed
+         This code is executed by a timer
+
     START   LICENSE CHANGED TO     CACHE   ACTION
-    BYOS-1  PAYG                   No      Register - Update Infra
-    BYOS-1  PAYG                   BYOS    Register - Update Infra
-    BYOS-1  BYOS-1                 No      Do nothing
-    BYOS-1  BYOS-1                 BYOS    Do nothing
-    BYOS-1  BYOS-2                 No      Do nothing
-    BYOS-1  BYOS-2                 BYOS    Do nothing
+1   BYOS-1  PAYG                   No      Register - Update Infra
+2   BYOS-1  PAYG                   BYOS    Register - Update Infra
+3   BYOS-1  BYOS-1                 No      Do nothing
+4   BYOS-1  BYOS-1                 BYOS    Do nothing
+5   BYOS-1  BYOS-2                 No      Do nothing
+6   BYOS-1  BYOS-2                 BYOS    Do nothing
 
-    BYOS-2  PAYG                   No      Do nothing
-    BYOS-2  PAYG                   BYOS    Re-register - Update Infra
-    BYOS-2  BYOS-1                 No      De-register - Update Infra
-    BYOS-2  BYOS-1                 BYOS    De-register - Update Infra
+7   BYOS-2  PAYG                   No      Do nothing
+8   BYOS-2  PAYG                   BYOS    Re-register - Update Infra
+9   BYOS-2  BYOS-1                 No      De-register - Update Infra
+10  BYOS-2  BYOS-1                 BYOS    De-register - Update Infra
+11  BYOS-3  PAYG                   No      No de-register from SCC, register with update infrastructure
+12  BYOS-3  PAYG                   BYOS    No de-register from SCC, register with update infrastructure
 
-    PAYG    BYOS-1                 No      De-register - Update Infra
-    PAYG    BYOS-1                 No      De-register - Update Infra
-    PAYG    BYOS-2                 No      Do nothing
-    PAYG    BYOS-2                 PAYG    Do nothing
-    PAYG    PAYG                   No      Do nothing
-    PAYG    PAYG                   PAYG    Do nothing
+13  PAYG    BYOS-1                 No      De-register - Update Infra
+14  PAYG    BYOS-1                 PAYG    De-register - Update Infra
+15  PAYG    BYOS-2,3               No      Do nothing
+16  PAYG    BYOS-2,3               PAYG    Do nothing
+17  PAYG    PAYG                   No      Do nothing
+18  PAYG    PAYG                   PAYG    Do nothing
 
 BYOS-1 -> BYOS unregistered
 BYOS-2 -> BYOS registered
+BYOS-3 -> BYOS Registered to SCC
 NOTE: When an instance starts the license_type value from IMDS is none (empty)
-START represents the state of the license type before running AHB
 """
 
 import logging
@@ -138,6 +143,7 @@ if ('BYOS' in license_type and not utils.uses_rmt_as_scc_proxy() and
         update_license_cache(license_type)
     if update_server and utils.is_registered(update_server.get_FQDN()):
         # system is registered to update infrastructure
+        # covers cases 9, 10, 13, 14
         run_command(['registercloudguest', '--clean'])
         run_command(['systemctl', 'disable', service_name])
 elif license_type and 'BYOS' not in license_type:
@@ -147,10 +153,16 @@ elif license_type and 'BYOS' not in license_type:
         license_has_changed = has_license_changed(license_type)
         if (not license_has_changed and
             utils.is_registered(update_server.get_FQDN())):
+            # covers cases 7, 15, 16, 17, 18
             sys.exit(0)
         if license_has_changed:
+            # cases 12
             update_license_cache(license_type)
         update_server = None
     if not update_server:
+        # cover cases 1, 2, 8
+        if has_license_changed(license_type):
+            # cover cases 2, 8
+            update_license_cache(license_type)
         run_command(['registercloudguest', '--force-new'])
         run_command(['systemctl', 'enable', service_name])

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -131,7 +131,7 @@ elif license_type and 'BYOS' not in license_type:
     # or PAYG without AHB
     if update_server:
         license_has_changed = has_license_changed(license_type)
-        if (license_has_changed == False and
+        if (not license_has_changed and
             utils.is_registered(update_server.get_FQDN())):
             sys.exit(0)
         if license_has_changed:

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -53,7 +53,7 @@ def has_license_changed(license_type):
             return license_type != old_license
     except FileNotFoundError:
         update_license_cache(license_type)
-        return False
+    return False
 
 def get_license_type():
     proxies = {

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -130,13 +130,15 @@ update_server = utils.get_smt()
 if ('BYOS' in license_type and not utils.uses_rmt_as_scc_proxy() and
     not utils.is_scc_connected()
 ):
+    # system license type has been set to BYOS via AHB but
+    # neither has been registered to the update infrastructure with a reg code
+    # nor to SCC
     license_has_changed = has_license_changed(license_type)
     if (license_has_changed or
         (update_server and utils.is_registered(update_server.get_FQDN()))
     ):
         # either license has changed or
         # system was previously registered to update infrastructure
-        # and neither SCC nor RMT as an SCC proxy
         if license_has_changed:
             update_license_cache(license_type)
         run_command(['registercloudguest', '--clean'])

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -16,15 +16,28 @@
 """
 Check the different states of the license type:
     START   LICENSE CHANGED TO     CACHE   ACTION
-    BYOS    SLES                   N/A     Register
-    BYOS    SLES                   BYOS    Register
-    BYOS    BYOS                   N/A     Do nothing
-    BYOS    BYOS                   BYOS    Do nothing
+    BYOS-1  SLES                   N/A     Register
+    BYOS-1  SLES                   BYOS    Register
+    BYOS-1  BYOS-1                 N/A     Do nothing
+    BYOS-1  BYOS-1                 BYOS    Do nothing
+    BYOS-1  BYOS-2                 N/A     Do nothing
+    BYOS-1  BYOS-2                 BYOS    Do nothing
 
-    SLES    BYOS                   N/A     De-register
-    SLES    BYOS                   SLES    De-register
+    BYOS-2  SLES                   N/A     Do nothing
+    BYOS-2  SLES                   BYOS    Re-register
+    BYOS-2  BYOS-1                 N/A     De-register
+    BYOS-2  BYOS-1                 BYOS    De-register
+
+    SLES    BYOS-1                 N/A     De-register
+    SLES    BYOS-1                 N/A     De-register
+    SLES    BYOS-2                 N/A     Do nothing
+    SLES    BYOS-2                 SLES    Do nothing
     SLES    SLES                   N/A     Do nothing
     SLES    SLES                   SLES    Do nothing
+
+BYOS-1 -> BYOS unregistered
+BYOS-2 -> BYOS registered
+NOTE: When an instance starts the license_type value from IMDS is none (empty)
 """
 
 import logging

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -16,24 +16,24 @@
 """
 Check the different states of the license type:
     START   LICENSE CHANGED TO     CACHE   ACTION
-    BYOS-1  SLES                   No      Register - Update Infra
-    BYOS-1  SLES                   BYOS    Register - Update Infra
+    BYOS-1  PAYG                   No      Register - Update Infra
+    BYOS-1  PAYG                   BYOS    Register - Update Infra
     BYOS-1  BYOS-1                 No      Do nothing
     BYOS-1  BYOS-1                 BYOS    Do nothing
     BYOS-1  BYOS-2                 No      Do nothing
     BYOS-1  BYOS-2                 BYOS    Do nothing
 
-    BYOS-2  SLES                   No      Do nothing
-    BYOS-2  SLES                   BYOS    Re-register - Update Infra
+    BYOS-2  PAYG                   No      Do nothing
+    BYOS-2  PAYG                   BYOS    Re-register - Update Infra
     BYOS-2  BYOS-1                 No      De-register - Update Infra
     BYOS-2  BYOS-1                 BYOS    De-register - Update Infra
 
-    SLES    BYOS-1                 No      De-register - Update Infra
-    SLES    BYOS-1                 No      De-register - Update Infra
-    SLES    BYOS-2                 No      Do nothing
-    SLES    BYOS-2                 SLES    Do nothing
-    SLES    SLES                   No      Do nothing
-    SLES    SLES                   SLES    Do nothing
+    PAYG    BYOS-1                 No      De-register - Update Infra
+    PAYG    BYOS-1                 No      De-register - Update Infra
+    PAYG    BYOS-2                 No      Do nothing
+    PAYG    BYOS-2                 PAYG    Do nothing
+    PAYG    PAYG                   No      Do nothing
+    PAYG    PAYG                   PAYG    Do nothing
 
 BYOS-1 -> BYOS unregistered
 BYOS-2 -> BYOS registered

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -37,7 +37,6 @@ def has_license_changed(license_type):
             return license_type != old_license
     except FileNotFoundError:
         update_license_cache(license_type)
-        raise
 
 
 def get_license_type():
@@ -99,14 +98,11 @@ service_name = 'guestregister'
 license_type = get_license_type()
 
 if ('BYOS' in license_type and not utils.uses_rmt_as_scc_proxy()):
-    try:
-        if not has_license_changed(license_type):
-            sys.exit(0)
+    license_has_changed = has_license_changed(license_type)
+    if license_has_changed in [False]:
+        sys.exit(0)
+    if license_has_changed:
         update_license_cache(license_type)
-    except FileNotFoundError:
-        # if cache file did not exist, it got created
-        # only thing left to do is to de-register
-        pass
     run_command(['registercloudguest', '--clean'])
     run_command(['systemctl', 'disable', service_name])
 elif license_type and 'BYOS' not in license_type:
@@ -114,17 +110,12 @@ elif license_type and 'BYOS' not in license_type:
     # or PAYG without AHB
     update_server = utils.get_smt()
     if update_server:
-        try:
-            license_has_changed = has_license_changed(license_type)
-            if (not license_has_changed and
-                utils.is_registered(update_server.get_FQDN())):
-                sys.exit(0)
-            if license_has_changed:
-                update_license_cache(license_type)
-        except FileNotFoundError:
-            # if cache file did not exit, it got created
-            # only thing left to do is to register
-            pass
+        license_has_changed = has_license_changed(license_type)
+        if (license_has_changed in [False] and
+            utils.is_registered(update_server.get_FQDN())):
+            sys.exit(0)
+        if license_has_changed:
+            update_license_cache(license_type)
         update_server = None
     if not update_server:
         run_command(['registercloudguest', '--force-new'])

--- a/usr/sbin/regionsrv-enabler-azure
+++ b/usr/sbin/regionsrv-enabler-azure
@@ -134,14 +134,10 @@ if ('BYOS' in license_type and not utils.uses_rmt_as_scc_proxy() and
     # system license type has been set to BYOS via AHB but
     # neither has been registered to the update infrastructure with a reg code
     # nor to SCC
-    license_has_changed = has_license_changed(license_type)
-    if (license_has_changed or
-        (update_server and utils.is_registered(update_server.get_FQDN()))
-    ):
-        # either license has changed or
-        # system was previously registered to update infrastructure
-        if license_has_changed:
-            update_license_cache(license_type)
+    if has_license_changed(license_type):
+        update_license_cache(license_type)
+    if update_server and utils.is_registered(update_server.get_FQDN()):
+        # system is registered to update infrastructure
         run_command(['registercloudguest', '--clean'])
         run_command(['systemctl', 'disable', service_name])
 elif license_type and 'BYOS' not in license_type:


### PR DESCRIPTION
When switching from SLES to BYOS and no cache file exists, the license changes to BYOS and no other action is done, instance/system is still registered

This change fixes that scenario