### PR TITLE
Update amazonec2.py to fix variable region reference before assigment

### DIFF
--- a/lib/cloudregister/amazonec2.py
+++ b/lib/cloudregister/amazonec2.py
@@ -86,7 +86,7 @@ def generateRegionSrvArgs():
             for c in region_id_az:
                 if c.isdigit():
                     region_id += c
-                    region = '-'.join(region_data[:2] + [region_id])
+            region = '-'.join(region_data[:2] + [region_id])
         else:
             logging.warning('Unable to get availability zone metadata')
             logging.warning('\tReturn code: %d' % zone_resp.status_code)


### PR DESCRIPTION
Update amazonec2.py to fix variable region reference before assigment i.e. `UnboundLocalError: local variable 'region' referenced before assignment`. This issue affects SLES based instances in the AWS GovCloud regions.

```
ip-172-31-30-71:~ # zypper up cloud-regionsrv-client \
>   cloud-regionsrv-client-plugin-ec2 \
>   regionServiceClientConfigEC2 \
>   python3-ec2metadata \
>   SUSEConnect

The following 11 items are locked and will not be changed by any action:
 Available:
  plymouth plymouth-branding-SLE plymouth-devel plymouth-dracut plymouth-plugin-label plymouth-plugin-label-ft plymouth-plugin-script plymouth-plugin-tribar plymouth-scripts plymouth-theme-tribar plymouth-x11-renderer

The following 2 packages are going to be upgraded:
  cloud-regionsrv-client cloud-regionsrv-client-plugin-ec2

2 packages to upgrade.
Overall download size: 102.3 KiB. Already cached: 0 B. After the operation, additional 4.5 KiB will be used.
Continue? [y/n/...? shows all options] (y): y
Retrieving package cloud-regionsrv-client-10.1.5-52.102.1.noarch                                                                                                                                                                    (1/2),  76.8 KiB (177.3 KiB unpacked)
Retrieving: cloud-regionsrv-client-10.1.5-52.102.1.noarch.rpm .....................................................................................................................................................................................................[done]
Retrieving package cloud-regionsrv-client-plugin-ec2-1.0.3-52.102.1.noarch                                                                                                                                                          (2/2),  25.5 KiB (  3.6 KiB unpacked)
Retrieving: cloud-regionsrv-client-plugin-ec2-1.0.3-52.102.1.noarch.rpm ...........................................................................................................................................................................................[done]

Checking for file conflicts: ......................................................................................................................................................................................................................................[done]
(1/2) Installing: cloud-regionsrv-client-10.1.5-52.102.1.noarch ...................................................................................................................................................................................................[done]
(2/2) Installing: cloud-regionsrv-client-plugin-ec2-1.0.3-52.102.1.noarch .........................................................................................................................................................................................[done]

ip-172-31-30-71:~ # SUSEConnect -s
[{"identifier":"SLES","version":"12.5","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-adv-systems-management","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-containers","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-hpc","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-legacy","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-public-cloud","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-toolchain","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-web-scripting","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-sdk","version":"12.5","arch":"x86_64","status":"Registered"}]

# python errors regarding 'region' variable 

ip-172-31-30-71:~ # registercloudguest --force-new
Traceback (most recent call last):
  File "/usr/sbin/registercloudguest", line 277, in <module>
    utils.write_framework_identifier(cfg)
  File "/usr/lib/python3.4/site-packages/cloudregister/registerutils.py", line 1402, in write_framework_identifier
    region_hint = __get_region_server_args(plugin)
  File "/usr/lib/python3.4/site-packages/cloudregister/registerutils.py", line 1461, in __get_region_server_args
    region_srv_args = plugin.generateRegionSrvArgs()
  File "/usr/lib/python3.4/site-packages/cloudregister/amazonec2.py", line 98, in generateRegionSrvArgs
    return 'regionHint=' + region
UnboundLocalError: local variable 'region' referenced before assignment

# Check again

ip-172-31-30-71:~ # SUSEConnect -s
[{"identifier":"SLES","version":"12.5","arch":"x86_64","status":"Not Registered"},{"identifier":"sle-module-adv-systems-management","version":"12","arch":"x86_64","status":"Not Registered"},{"identifier":"sle-module-containers","version":"12","arch":"x86_64","status":"Not Registered"},{"identifier":"sle-module-hpc","version":"12","arch":"x86_64","status":"Not Registered"},{"identifier":"sle-module-legacy","version":"12","arch":"x86_64","status":"Not Registered"},{"identifier":"sle-module-public-cloud","version":"12","arch":"x86_64","status":"Not Registered"},{"identifier":"sle-module-toolchain","version":"12","arch":"x86_64","status":"Not Registered"},{"identifier":"sle-module-web-scripting","version":"12","arch":"x86_64","status":"Not Registered"},{"identifier":"sle-sdk","version":"12.5","arch":"x86_64","status":"Not Registered"}]
```

```
ip-172-31-30-71:~ # rpm -ql cloud-regionsrv-client-plugin-ec2
/usr/lib/python3.4/site-packages/cloudregister/amazonec2.py

ip-172-31-30-71:~ # vim /usr/lib/python3.4/site-packages/cloudregister/amazonec2.py
```

After implementing fix:

```
ip-172-31-30-71:~ # registercloudguest --force-new
Registration succeeded

ip-172-31-30-71:~ # SUSEConnect -s
[{"identifier":"SLES","version":"12.5","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-adv-systems-management","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-containers","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-hpc","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-legacy","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-public-cloud","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-toolchain","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-module-web-scripting","version":"12","arch":"x86_64","status":"Registered"},{"identifier":"sle-sdk","version":"12.5","arch":"x86_64","status":"Registered"}]
```