### PR TITLE
Add handling case when no credentials present

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -160,6 +160,9 @@ def credentials_files_are_equal(repo_credentials):
     """Compare the base credentials files the the repo header and make
        sure they have the same values."""
     credentials_location = '/etc/zypp/credentials.d/'
+    if repo_credentials is None:
+        return False
+
     credentials_base = os.path.join(credentials_location, 'SCCcredentials')
     credentials_header = os.path.join(credentials_location, repo_credentials)
     ref_user, ref_pass = get_credentials(credentials_base)

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -616,6 +616,10 @@ def test_credentials_files_are_equal(mock_get_credentials):
     assert utils.credentials_files_are_equal('foo') == False
 
 
+def test_credentials_files_are_equal_no_credentials():
+    assert utils.credentials_files_are_equal(None) is False
+
+
 @patch('cloudregister.registerutils.logging')
 @patch('cloudregister.registerutils.exec_subprocess')
 def test_enable_repository(mock_exec_subprocess, mock_logging):


### PR DESCRIPTION
In the case of no credentials present,
the check of credentials should not generate
an exception