### PR TITLE
Update regionserverclnt.cfg with new cert path

### DIFF
--- a/etc/regionserverclnt.cfg
+++ b/etc/regionserverclnt.cfg
@@ -1,12 +1,13 @@
 [server]
 api = regionInfo
-certLocation = /var/lib/regionService/certs
+certLocation = /usr/lib/regionService/certs
 regionsrv = COMMA_SEP_LIST_OF_CLOUD_SPECIFIC_REGION_SERVER
 metadata_server = OPTIONAL_URL_FOR_METADATA_SERVER_SMT_INFO
 
 [instance]
 dataProvider = none
 instanceArgs = none
+httpsOnly = true
 
 [service]
 verifyAccess = none

--- a/integration_test-process.txt
+++ b/integration_test-process.txt
@@ -57,9 +57,9 @@ After installing the test package with "zypper in"
   + no error no message
   + zypper lr has no repos
 - SUSEConnect -r XXX
-  + registartion successful
+  + registration successful
 - SUSEConnect -p sle-module-public-cloud/$VERSION/x86_64
-  + registartion successful
+  + registration successful
 - SUSEConnect -d -p sle-module-public-cloud/$VERSION/x86_64
   + module deletion successful
   + Requires SUSEConnect > 0.3.32
@@ -79,7 +79,7 @@ After installing the test package with "zypper in"
   + $? is 0
   + repos include HA
 - SUSEConnect -p sle-module-public-cloud/$VERSION/x86_64
-  + registartion successful
+  + registration successful
   + Cloud based RMT server is the target
 - registercloudguest --clean
 

--- a/tests/data/regionserverclnt.cfg
+++ b/tests/data/regionserverclnt.cfg
@@ -1,5 +1,5 @@
 [server]
 api = regionInfo
-certLocation = /var/lib/regionService/certs
+certLocation = /usr/lib/regionService/certs
 regionsrv = COMMA_SEP_LIST_OF_CLOUD_SPECIFIC_REGION_SERVER
 metadata_server = OPTIONAL_URL_FOR_METADATA_SERVER_SMT_INFO

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -133,7 +133,7 @@ argparse.add_argument(
     '-d', '--delay',
     default=0,
     dest='delay_time',
-    help='Delay the start of registartion by given value in seconds',
+    help='Delay the start of registration by given value in seconds',
     type=int
 )
 # default config file location not set it is encoded in the utils function


### PR DESCRIPTION
Update regionserverclnt.cfg with new certLocation i.e. /usr/lib/regionService/certs and address some minor typos.