### PR TITLE
Disable insecure request warning

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -46,6 +46,10 @@ REGISTRATION_DATA_DIR = '/var/cache/cloudregister/'
 REGISTERED_SMT_SERVER_DATA_FILE_NAME = 'currentSMTInfo.obj'
 RMT_AS_SCC_PROXY_MARKER = 'rmt_is_scc_proxy'
 
+requests.packages.urllib3.disable_warnings(
+    requests.packages.urllib3.exceptions.InsecureRequestWarning
+)
+
 
 # ----------------------------------------------------------------------------
 def add_hosts_entry(smt_server):
@@ -505,9 +509,6 @@ def get_credentials(credentials_file):
 # ----------------------------------------------------------------------------
 def refresh_registry_credentials():
     """Refresh registry credentials."""
-    # to silence InsecureRequestWarning
-    # should be fixed on a different PR
-    requests.packages.urllib3.disable_warnings()
     return get_activations()
 
 

--- a/lib/cloudregister/smt.py
+++ b/lib/cloudregister/smt.py
@@ -47,6 +47,12 @@ class SMT:
         if https_only:
             self._protocol = 'https'
         self._check_urls = self._form_srv_check_urls()
+        # disable InsecureRequestWarning
+        # as verification is disabled for the https request
+        requests.packages.urllib3.disable_warnings(
+            requests.packages.urllib3.exceptions.InsecureRequestWarning
+        )
+
 
     # --------------------------------------------------------------------
     def __eq__(self, other_smt):

--- a/lib/cloudregister/smt.py
+++ b/lib/cloudregister/smt.py
@@ -53,7 +53,6 @@ class SMT:
             requests.packages.urllib3.exceptions.InsecureRequestWarning
         )
 
-
     # --------------------------------------------------------------------
     def __eq__(self, other_smt):
         if not isinstance(other_smt, SMT):


### PR DESCRIPTION
In order to check whether a RMT server is responsive, a https request is triggered with verification disable making the request to show a warning

This PR silences that warning