### PR TITLE
Add header for reauth purposes

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -404,7 +404,7 @@ def find_repos(contains_name):
 
 
 # ----------------------------------------------------------------------------
-def get_activations():
+def get_activations(registry=False):
     """Get the activated products from the update server"""
     update_server = get_smt()
     user, password = get_credentials(get_credentials_file(update_server))
@@ -419,6 +419,8 @@ def get_activations():
 
     instance_data = bytes(get_instance_data(get_config()), 'utf-8')
     headers = {'X-Instance-Data': base64.b64encode(instance_data)}
+    if registry:
+        headers['X-Registry'] = user
 
     res = requests.get(
         'https://%s/connect/systems/activations' % update_server.get_FQDN(),
@@ -508,7 +510,7 @@ def refresh_registry_credentials():
     # to silence InsecureRequestWarning
     # should be fixed on a different PR
     requests.packages.urllib3.disable_warnings()
-    return get_activations()
+    return get_activations(True)
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -1121,23 +1121,23 @@ def test_get_activations_request_registry_header(
          region="antarctica-1"/>''')
     smt_server = SMT(etree.fromstring(smt_data_ipv46))
     mock_get_smt.return_value = smt_server
-    mock_get_creds.return_value = 'foo', 'bar'
-    mock_http_basic_auth.return_value = 'foobar'
+    mock_get_creds.return_value = 'username_foo', 'password_bar'
+    mock_http_basic_auth.return_value = 'http_basic_auth_from_userpass'
     mock_get_instance_data.return_value = 'super_instance_data'
     response = Response()
     response.status_code = 200
     json_mock = Mock()
-    json_mock.return_value = {"foo": "bar"}
+    json_mock.return_value = {"prod": "activated"}
     response.json = json_mock
     mock_request_get.return_value = response
-    assert utils.get_activations(True) == {'foo': 'bar'}
+    assert utils.get_activations(True) == {'prod': 'activated'}
     assert mock_logging.error.not_called
     mock_request_get.assert_called_once_with(
         'https://fantasy.example.com/connect/systems/activations',
-        auth='foobar',
+        auth='http_basic_auth_from_userpass',
         headers={
             'X-Instance-Data': b'c3VwZXJfaW5zdGFuY2VfZGF0YQ==',
-            'X-Registry': 'foo'
+            'X-Registry': 'username_foo'
         }
     )
 


### PR DESCRIPTION
- When refreshing the credentials server side, add a header to explicitly set the registry cache file