### PR TITLE
Clean for BYOS fails

### DIFF
--- a/lib/cloudregister/smt.py
+++ b/lib/cloudregister/smt.py
@@ -107,7 +107,7 @@ class SMT:
     # --------------------------------------------------------------------
     def get_registry_FQDN(self):
         """Return the fully qualified domain registry name"""
-        return self._registry_fqdn
+        return self._registry_fqdn if hasattr(self, '_registry_fqdn') else ''
 
     # --------------------------------------------------------------------
     def get_name(self):


### PR DESCRIPTION
When registering or deregistering a BYOS unregistered instance, the cache SMT object does not have the attribute for registry FQDN