### PR TITLE
Sle12 ports

### DIFF
--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -44,7 +44,9 @@ Requires:       python3-lxml
 Requires:       python3-requests
 Requires:       python3-urllib3
 Requires:       python3-zypp-plugin
+%if 0%{?suse_version} > 1315
 Requires:       python3-toml
+%endif
 Requires:       regionsrv-certs
 Requires:       sudo
 Requires:       zypper
@@ -63,7 +65,9 @@ BuildRequires:  python3-lxml
 BuildRequires:  python3-requests
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-zypp-plugin
+%if 0%{?suse_version} > 1315
 BuildRequires:  python3-toml
+%endif
 BuildRequires:  sudo
 BuildRequires:  systemd-rpm-macros
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -132,8 +136,10 @@ Enable/Disable Guest Registration for Microsoft Azure
 %prep
 %setup -q
 %if 0%{?suse_version} == 1315
-%patch0
-%patch1
+%patch -P 0
+%patch -P 1
+test -e usr/sbin/registercloudguest.orig && rm usr/sbin/registercloudguest.orig
+test -e lib/cloudregister/registerutils.py.orig && rm lib/cloudregister/registerutils.py.orig
 %endif
 
 %build

--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -27,6 +27,8 @@ URL:            http://www.github.com/SUSE-Enceladus/cloud-regionsrv-client
 Source0:        %{name}-%{version}.tar.bz2
 # PATCH-FIX-SLES12 bsc#1203382 fix-for-sles12-disable-ipv6.patch
 Patch0:         fix-for-sles12-disable-ipv6.patch
+# PATCH-FIX-SLES12 fix-for-sles12-disable-registry.patch
+Patch1:         fix-for-sles12-disable-registry.patch
 Requires:       SUSEConnect > 0.3.31
 Requires:       ca-certificates
 Requires:       cloud-regionsrv-client-config
@@ -131,6 +133,7 @@ Enable/Disable Guest Registration for Microsoft Azure
 %setup -q
 %if 0%{?suse_version} == 1315
 %patch0
+%patch1
 %endif
 
 %build

--- a/fix-for-sles12-disable-ipv6.patch
+++ b/fix-for-sles12-disable-ipv6.patch
@@ -1,0 +1,10 @@
+--- lib/cloudregister/smt.py.orig
++++ lib/cloudregister/smt.py
+@@ -109,6 +109,7 @@ class SMT:
+     # --------------------------------------------------------------------
+     def get_ipv6(self):
+         """Return the IP address"""
++        return None
+         # Before handling ipv6 the IP address was stored in the _ip
+         # member. When the SMT object is restored from an old pickeled
+         # file the _ipv6 member does not exist. Handle this transition

--- a/fix-for-sles12-disable-registry.patch
+++ b/fix-for-sles12-disable-registry.patch
@@ -1,0 +1,68 @@
+--- lib/cloudregister/registerutils.py
++++ lib/cloudregister/registerutils.py
+@@ -30,7 +30,8 @@ import stat
+ import subprocess
+ import sys
+ import time
+-import toml
++# Disabled on SLE12
++# import toml
+ import yaml
+ 
+ from lxml import etree
+@@ -72,11 +73,12 @@ def add_hosts_entry(smt_server):
+         smt_server.get_FQDN(),
+         smt_server.get_name()
+     )
+-    if smt_server.get_registry_FQDN():
+-        entry += '%s\t%s\n' % (
+-            smt_ip,
+-            smt_server.get_registry_FQDN()
+-        )
++    # Disabled on SLE12
++    # if smt_server.get_registry_FQDN():
++    #     entry += '%s\t%s\n' % (
++    #         smt_ip,
++    #         smt_server.get_registry_FQDN()
++    #     )
+ 
+     with open('/etc/hosts', 'a') as hosts_file:
+         hosts_file.write(smt_hosts_entry_comment)
+@@ -667,6 +669,8 @@ def set_registries_conf(registry_fqdn):
+ 
+ # ----------------------------------------------------------------------------
+ def get_registry_conf_file(container_path, container):
++    # Disabled on SLE12
++    return None
+     registries_conf = {}
+     try:
+         with open(container_path, 'r') as registries_conf_file:
+@@ -712,6 +716,8 @@ def update_bashrc(content, mode):
+ 
+ # ----------------------------------------------------------------------------
+ def clean_registry_setup():
++    # Disabled on SLE12
++    return None
+     """Remove the data previously set to make the registry work."""
+     smt = get_smt_from_store(__get_registered_smt_file_path())
+     private_registry_fqdn = smt.get_registry_FQDN() if smt else ''
+@@ -1046,6 +1052,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
+ # ----------------------------------------------------------------------------
+ def write_registries_conf(registries_conf, container_path, container_name):
+     """Write registries_conf content to container_path."""
++    # Disabled on SLE12
++    return None
+     try:
+         if container_name == 'podman':
+             with open(container_path, 'w') as registries_conf_file:
+--- usr/sbin/registercloudguest
++++ usr/sbin/registercloudguest
+@@ -243,6 +243,8 @@ def setup_registry(registration_target, clean='registry'):
+     clean == all -> cleans repository and registry setup
+     clean == registry -> clean only registry artifacts
+     """
++    # Disabled on SLE12
++    return None
+     user, password = utils.get_credentials(
+         utils.get_credentials_file(registration_target)
+     )


### PR DESCRIPTION
For SLE12 some patches to the registration client are needed. I moved the existing patch to the git and also added a new one which we need because we don't support the registry registration on SLE12