### PR TITLE
Add SUSEConnect command for testing

### DIFF
--- a/integration_test-process.txt
+++ b/integration_test-process.txt
@@ -15,6 +15,8 @@ After installing the test package with "zypper in"
   + registration success
     - check log
   + zypper lr has repos
+  + SUSEConnect -s shows the registration status
+  + SUSEConnect -l shows a list of modules/extensions available or installed
 - registercloudguest --clean
   + no error no message
   + zypper lr has no repos


### PR DESCRIPTION
Those commands use the same method that registry engine uses on RMT to verify cache access, so they must work as expected