### PR TITLE
Fix sequence order for initial registry setup

### DIFF
--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -680,9 +680,6 @@ if utils.uses_rmt_as_scc_proxy():
 # is responsive and use it as registration target
 registration_target = get_responding_update_server(region_smt_servers)
 
-# Setup container registry
-setup_registry(registration_target)
-
 # Create location to store data if it does not exist
 if not os.path.exists(utils.get_state_dir()):
     os.system('mkdir -p %s' % utils.get_state_dir())
@@ -828,6 +825,9 @@ if registration_returncode:
         ), file=sys.stderr
     )
     sys.exit(registration_returncode)
+
+# Setup container registry
+setup_registry(registration_target)
 
 print('Registration succeeded')
 


### PR DESCRIPTION
As part of the LTSS changes in the registration client the initial setup of the registry moved before the base product setup. This was considered not an issue but it is one. That's because the setup of the registry reads the RMT credentials from /etc/zypp/credentials.d/SCCcredentials which only exists after the initial base product registration. This means the initial registry setup has to follow the initial base product registration. This commit fixes it