### PR TITLE
Fixed setup of registry hosts entry

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -1104,7 +1104,7 @@ def get_credentials_file(update_server, service_name=None):
 
 
 # ----------------------------------------------------------------------------
-def get_hosts():
+def get_hosts(with_loopback=False):
     """
     Read /etc/hosts file into the following structure
 
@@ -1124,6 +1124,12 @@ def get_hosts():
     for line in hostlines:
         hostnames = line.split('#')[0].split()[1:]
         hostaddress = line.split('#')[0].split()[0]
+        loopback = False
+        if hostaddress == '::1' or hostaddress == '127.0.0.1':
+            loopback = True
+        if not with_loopback and loopback:
+            # no loopback addresses wanted
+            continue
         for hostname in hostnames:
             hosts[hostname] = {
                 'address': hostaddress,
@@ -1554,15 +1560,25 @@ def has_region_changed(cfg):
 
 # ----------------------------------------------------------------------------
 def has_rmt_in_hosts(server):
-    """Check if an entry for the given update server is in the hosts file"""
-    with open('/etc/hosts') as hosts_file:
-        hosts_content = hosts_file.read()
-    srv_ipv4 = server.get_ipv4()
-    srv_ipv6 = server.get_ipv6()
-
-    if srv_ipv4 in hosts_content or srv_ipv6 in hosts_content:
+    """
+    Check if an entry for the given update server is in the hosts file
+    """
+    hosts = get_hosts()
+    rmt_server_name = server.get_FQDN()
+    if rmt_server_name in hosts.keys():
         return True
+    return False
 
+
+# ----------------------------------------------------------------------------
+def has_registry_in_hosts(server):
+    """
+    Check if an entry for the given registry server is in the hosts file
+    """
+    hosts = get_hosts()
+    registry_server_name = server.get_registry_FQDN()
+    if registry_server_name in hosts.keys():
+        return True
     return False
 
 

--- a/tests/data/hosts
+++ b/tests/data/hosts
@@ -23,3 +23,9 @@ ff02::3         ipv6-allhosts
 
 # other hosts
 192.0.2.1   some.box
+
+1.1.1.1   smt-foo.susecloud.net  smt-foo
+1.1.1.1   registry-foo.susecloud.net
+
+11:22:33:44::00   smt-foo.susecloud.net  smt-foo
+11:22:33:44::00   registry-foo.susecloud.net

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -265,89 +265,34 @@ def test_is_registration_supported_RHEL_Family():
     assert utils.is_registration_supported(cfg) is False
 
 
-def test_has_rmt_in_hosts_has_ipv4():
-    hosts_content = """
-    # simulates hosts file containing the ipv4 we are looking for in the test
+def test_has_rmt_in_hosts():
+    utils.HOSTSFILE_PATH = '{0}/hosts'.format(data_path)
+    server = Mock()
 
-    1.1.1.1   smt-foo.susecloud.net  smt-foo
-    1.1.1.1   registry-foo.susecloud.net
-    """
-    server = MockServer()
-    with patch('builtins.open', mock_open(read_data=hosts_content)):
-        has_entry = utils.has_rmt_in_hosts(server)
+    # The following entry is expected to be found
+    server.get_FQDN = Mock(return_value='smt-foo.susecloud.net')
+    assert utils.has_rmt_in_hosts(server) is True
 
-    assert has_entry is True
+    # The following entry is expected to be not found
+    server.get_FQDN = Mock(return_value='bogus')
+    assert utils.has_rmt_in_hosts(server) is False
 
-
-def test_has_rmt_in_hosts_has_ipv4_6():
-    hosts_content = """
-    # simulates hosts file containing the ipv4 and iv6 we are looking for
-    # in the test
-
-    1.1.1.1   smt-foo.susecloud.net  smt-foo
-    1.1.1.1   registry-foo.susecloud.net
-    11:22:33:44::00   smt-foo.susecloud.net  smt-foo
-    11:22:33:44::00   registry-foo.susecloud.net
-    """
-    server = MockServer()
-    with patch('builtins.open', mock_open(read_data=hosts_content)):
-        has_entry = utils.has_rmt_in_hosts(server)
-
-    assert has_entry is True
+    utils.HOSTSFILE_PATH = '/etc/hosts'
 
 
-def test_has_rmt_in_hosts_ipv4_not_found():
-    hosts_content = """
-    # simulates hosts file containing a different ipv4
+def test_has_registry_in_hosts():
+    utils.HOSTSFILE_PATH = '{0}/hosts'.format(data_path)
+    server = Mock()
 
-    2.1.1.1   smt-foo.susecloud.net  smt-foo
-    """
-    server = MockServer()
-    with patch('builtins.open', mock_open(read_data=hosts_content)):
-        has_entry = utils.has_rmt_in_hosts(server)
+    # The following entry is expected to be found
+    server.get_registry_FQDN = Mock(return_value='registry-foo.susecloud.net')
+    assert utils.has_registry_in_hosts(server) is True
 
-    assert has_entry is False
+    # The following entry is expected to be not found
+    server.get_registry_FQDN = Mock(return_value='bogus')
+    assert utils.has_registry_in_hosts(server) is False
 
-
-def test_has_rmt_in_hosts_has_ipv6():
-    hosts_content = """
-    # simulates hosts file containing the ipv6 we are looking for in the test
-
-    11:22:33:44::00   smt-foo.susecloud.net  smt-foo
-    """
-    server = MockServer()
-    with patch('builtins.open', mock_open(read_data=hosts_content)):
-        has_entry = utils.has_rmt_in_hosts(server)
-
-    assert has_entry is True
-
-
-def test_has_rmt_in_hosts_has_ipv6_4():
-    hosts_content = """
-    # simulates hosts file containing the ipv4 and iv6 we are looking for
-    # in the test
-
-    11:22:33:44::00   smt-foo.susecloud.net  smt-foo
-    1.1.1.1   smt-foo.susecloud.net  smt-foo
-    """
-    server = MockServer()
-    with patch('builtins.open', mock_open(read_data=hosts_content)):
-        has_entry = utils.has_rmt_in_hosts(server)
-
-    assert has_entry is True
-
-
-def test_has_rmt_in_hosts_ipv6_not_found():
-    hosts_content = """
-    # simulates hosts file containing the ipv6 we are looking for in the test
-
-    22:22:33:44::00   smt-foo.susecloud.net  smt-foo
-    """
-    server = MockServer()
-    with patch('builtins.open', mock_open(read_data=hosts_content)):
-        has_entry = utils.has_rmt_in_hosts(server)
-
-    assert has_entry is False
+    utils.HOSTSFILE_PATH = '/etc/hosts'
 
 
 def test_clean_host_file_no_empty_bottom_lines():

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -625,6 +625,10 @@ if registration_smt:
             if not utils.has_rmt_in_hosts(registration_smt):
                 utils.clean_hosts_file(registration_smt.get_domain_name())
                 utils.add_hosts_entry(registration_smt)
+        # The registry target may be missing, write if necessary
+        if not utils.has_registry_in_hosts(registration_smt):
+            utils.clean_hosts_file(registration_smt.get_domain_name())
+            utils.add_hosts_entry(registration_smt)
         logging.info(msg)
         registration_target_found = True
     else:


### PR DESCRIPTION
There is a logic error in the code that sets up the hosts entry. One method named add_hosts_entry() is responsible for setting up the RMT and the registry hosts entries. Both entries targets the same server IP and can only be differentiated by their name and not by their IP. Next to this design there is a method named has_rmt_in_hosts() which checks by the IP of the server if the hosts entry exists or not. Obviously this condition check is not sufficient if there is the need to check individually for the hosts entry of the RMT target or the registry target.

At the time we added support for the container registry target, we require a more specific host entry checking which is specific to the target system we want to add the hosts entry for. This is because there are instances which can run an old version of cloud-regionsrv-client that only has support for the RMT target and therefore has added a proper hosts entry for this target. If a customer now updates cloud-regionsrv-client, the next reboot or manual call for registercloudguest adds support for the registry but did not update the hosts file because due to the checking above the code thought everything is ok because the IP based check for the hosts entry said everything is good.

To fix this I changed the way how has_rmt_in_hosts() works by using the new get_hosts() interface as well as checking for the FQDN for RMT and not the IP. In addition I added a new method called has_registry_in_hosts() which checks for the FQDN for the registry. has_registry_in_hosts() is then used to make sure a hosts entry for the registry exists independently of the case that there is a RMT hosts entry already present. This Fixes #195