### PR TITLE
Fix docker config file mirror settings

### DIFF
--- a/integration_test-process.txt
+++ b/integration_test-process.txt
@@ -28,6 +28,36 @@ After installing the test package with "zypper in"
   + sucees message on stdout
   + $? is 0
   + zypper lr has repos
+  On SLE 15
+  + cat /etc/docker/daemon.json
+    - Should have registry for the update infrastructure and registry.suse.com
+  + cat /etc/containers/registries.conf
+    - Should have registry for the update infrastructure and registry.suse.com
+  + grep REGISTRY_AUTH_FILE /etc/profile.local
+  + grep DOCKER_CONFIG /etc/profile.local
+  + source /etc/profile.local
+  + systemctl start docker.service
+  + systemctl status docker.service
+    - Service should be running
+  + docker pull bci/bci-base
+    - Should pull the container from registry.suse.com
+  + systemctl stop docker.service
+  + zypper in podman
+  + podman pull bci/bci-base
+- registercloudguest --clean
+  + zypper lr has no repos
+  On SLE 15
+  + cat /etc/docker/daemon.json
+    - File does not exist or
+    - No reference to registry on update infrastructure and registry.suse.com
+  + cat /etc/containers/registries.conf
+    - File does not exist or
+    - No reference to registry on update infrastructure and registry.suse.com
+  + grep REGISTRY_AUTH_FILE /etc/profile.local
+    - Turns up empty
+  + grep DOCKER_CONFIG /etc/profile.local
+    - Turns up empty
+- registercloudguest
 - registercloudguest --force-new
   + no error
   + success message on stdout

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -4368,7 +4368,9 @@ def test_clean_registries_conf_docker_file_clean_content_smt_OK(
     mock_os_path_exists.return_value = True
     mock_json_load.return_value = {
         'registry-mirrors': [
-            'foo.com', 'registry.suse.com', 'registry-foo.susecloud.net'
+            'foo.com',
+            'https://registry.suse.com',
+            'https://registry-foo.susecloud.net'
         ]
     }
     with patch('builtins.open', create=True) as mock_open:
@@ -4380,8 +4382,8 @@ def test_clean_registries_conf_docker_file_clean_content_smt_OK(
         ]
         assert mock_logging.info.call_args_list == [
             call(
-                'Registry content for /etc/docker/daemon.json has '
-                'been removed, updating that file'
+                'Registry content for "/etc/docker/daemon.json" has '
+                'been modified'
             ),
             call('File /etc/docker/daemon.json updated')
         ]
@@ -4401,8 +4403,9 @@ def test_clean_registries_conf_docker_file_clean_content_smt_OK_empty(
 ):
     mock_os_path_exists.return_value = True
     registry_fqdn = 'registry-foo.susecloud.net'
+    registry_url = 'https://' + registry_fqdn
     mock_json_load.return_value = {
-        'registry-mirrors': ['registry.suse.com', registry_fqdn]
+        'registry-mirrors': ['https://registry.suse.com', registry_url]
     }
     with patch('builtins.open', create=True) as mock_open:
         assert utils.clean_registries_conf_docker(registry_fqdn) is None
@@ -4444,8 +4447,8 @@ def test_clean_registries_conf_docker_file_clean_content_no_smt(
         ]
         assert mock_logging.info.call_args_list == [
             call(
-                'Registry content for /etc/docker/daemon.json has '
-                'been removed, updating that file'
+                'Registry content for "/etc/docker/daemon.json" has '
+                'been modified'
             ),
             call('File /etc/docker/daemon.json updated')
         ]
@@ -4506,7 +4509,7 @@ def test_set_registries_conf_docker_no_matches(
         mock_json_dump.assert_called_once_with(
             {
                 'registry-mirrors': [
-                    'registry-foo.susecloud.net',
+                    'https://registry-foo.susecloud.net',
                     'https://registry.suse.com',
                     'foo'
                 ],
@@ -4535,7 +4538,7 @@ def test_set_registries_conf_docker_unordered_matches(
             'registry-mirrors': [
                 'foo',
                 'https://registry.suse.com',
-                'registry-foo.susecloud.net'
+                'https://registry-foo.susecloud.net'
             ],
             'bar': ['bar'],
         }, False
@@ -4543,7 +4546,7 @@ def test_set_registries_conf_docker_unordered_matches(
         mock_json_dump.assert_called_once_with(
             {
                 'registry-mirrors': [
-                    'registry-foo.susecloud.net',
+                    'https://registry-foo.susecloud.net',
                     'https://registry.suse.com',
                     'foo'
                 ],
@@ -4574,7 +4577,7 @@ def test_set_registries_conf_docker_not_key_mirror(
             {
                 'foo': ['foo'],
                 'registry-mirrors': [
-                    'registry-foo.susecloud.net',
+                    'https://registry-foo.susecloud.net',
                     'https://registry.suse.com'
                 ]
             },


### PR DESCRIPTION
Per docker documentation setting a registry mirror requires a url. Previously we wrote the fqdn of the update server to the daemon.json which breaks docker daemon start up with the 'unsupported scheme "" ' message. Convert the fqdn into a url.