### PR TITLE
Handle process structure change

### DIFF
--- a/integration_test-process.txt
+++ b/integration_test-process.txt
@@ -125,6 +125,26 @@ After installing the test package with "zypper in"
   + Cloud based RMT server is the target
 - registercloudguest --clean
 
+Migration testing
+SLE 15
+- Start a PAYG instance 2 SPs back from the current one
+- Check the instance is properly registered
+- zypper up
+  + Expected to succeed
+- With the new cloud-regionsrv-client code in place run "zypper migration"
+  + Migrate to the highest available SP
+  + Expected to succeed
+- Start a BYOS instance 2 SPs back from the current one
+- registercloudguest -r XXX
+  + no error
+  + sucees message on stdout
+- Add the Public Cloud Module if it is not setup
+- zypper up
+  + Expected to succeed
+- With the new cloud-regionsrv-client code in place run "zypper migration"
+  + Migrate to the highest available SP
+  + Expected to succeed
+
 Extended testing
 - Clean out /var/log/cloudregister
 - Create an image from a registered instance (PAYG)

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -1452,7 +1452,7 @@ def get_zypper_pid():
         zyppPIDCmd = ['ps', '-C', executable_name, '-o', 'pid=']
         zyppPID = subprocess.Popen(zyppPIDCmd, stdout=subprocess.PIPE)
         pidData = zyppPID.communicate()
-        pid = pidData[0].strip().decode()
+        pid = pidData[0].decode().split('\n')[0].strip()
         if pid:
             break
 

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -1980,14 +1980,25 @@ def test_get_zypper_command(mock_zypper_pid):
 
 
 @patch('cloudregister.registerutils.subprocess.Popen')
-def test_get_zypper_pid(mock_popen):
+def test_get_zypper_pid_one_pid(mock_popen):
     mock_process = Mock()
     mock_process.communicate = Mock(
-        return_value=[str.encode('pid'), str.encode('stderr')]
+        return_value=[str.encode('12345 '), str.encode('stderr')]
     )
     mock_process.returncode = 0
     mock_popen.return_value = mock_process
-    assert utils.get_zypper_pid() == 'pid'
+    assert utils.get_zypper_pid() == '12345'
+
+
+@patch('cloudregister.registerutils.subprocess.Popen')
+def test_get_zypper_pid_with_child_pid(mock_popen):
+    mock_process = Mock()
+    mock_process.communicate = Mock(
+        return_value=[str.encode('12345\n    6789\n'), str.encode('stderr')]
+    )
+    mock_process.returncode = 0
+    mock_popen.return_value = mock_process
+    assert utils.get_zypper_pid() == '12345'
 
 
 @patch('cloudregister.registerutils.has_ipv6_access')


### PR DESCRIPTION
During migration the various process get spawned. When looking for the main zypper executable (Zypp-main) we also get information about the child process. However we are only interested in the main process PID. Change the logic to extract the PID such the we only look at the PID for the main process.