### PR TITLE
Make network access check message less alarming

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -246,7 +246,7 @@ def fetch_smt_data(cfg, proxies, quiet=False):
         except Exception as e:
             logging.error('=' * 20)
             logging.error(str(e))
-            logging.error('Unable to obtain SMT server information, exiting')
+            logging.error('Unable to obtain update server information, exiting')
             sys.exit(1)
         smt_info = json.loads(response.text)
         expected_entries = ('fingerprint', 'SMTserverIP', 'SMTserverName')
@@ -1485,6 +1485,25 @@ def get_zypper_target_root():
 
 
 # ----------------------------------------------------------------------------
+def has_network_access_by_ip_address(server_ip):
+    """Check if we can connect to the given server"""
+    try:
+        connection = socket.create_connection((server_ip, 443), timeout=2)
+    except OSError:
+        try:
+            ip_ver = 'IPv%d' % ipaddress.ip_address(server_ip).version
+        except ValueError:
+            ip_ver = 'UNKNOWN'
+        logging.info(
+            'Skipping %s protocol version, no network configuration' % ip_ver
+            )
+        return False
+
+    connection.close()
+    return True
+
+
+# ----------------------------------------------------------------------------
 def has_rmt_ipv6_access(smt):
     """IPv6 access is possible if we have an SMT server that has an IPv6
        address and it can be accessed over IPv6"""
@@ -2084,19 +2103,6 @@ def has_ipv4_access():
 def has_ipv6_access():
     """Check if we have IPv6 network configuration"""
     return has_network_access_by_ip_address('2001:4860:4860::8888')
-
-
-# ----------------------------------------------------------------------------
-def has_network_access_by_ip_address(server_ip):
-    """Check if we can connect to the given server"""
-    try:
-        connection = socket.create_connection((server_ip, 443), timeout=2)
-    except OSError as e:
-        logging.info('Network access error: "%s"', e)
-        return False
-
-    connection.close()
-    return True
 
 
 # ----------------------------------------------------------------------------

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -470,7 +470,8 @@ if args.user_smt_ip or args.user_smt_fqdn or args.user_smt_fp:
             'Please, make sure the network configuration supports the '
             'provided {ip} address version.'.format(ip=args.user_smt_ip)
         )
-        sys.exit(error_message)
+        print(error_message, file=sys.stderr)
+        sys.exit(1)
 
 
 if args.clean_up and args.force_new_registration:


### PR DESCRIPTION
At present when we test for network access by IP protocol version the message in the log file makes it hard to differentiate whether this is hard error or for information. While the message is set as info it still contains the word "error" in the message. Make the message less alarming in an attempt to not train users to ignore errors.

Enhance the testing of the function checking the network access. Previously only the happy path was tested.

Make the network acces test function private to the utils, we do not want function to be used outside the utils. Client code should use the test methods for IPv4 and IPv6 access.