### PR TITLE
Remove superfluous condition

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -1485,6 +1485,21 @@ def get_zypper_target_root():
 
 
 # ----------------------------------------------------------------------------
+def has_network_access_by_ip_address(server_ip, ip_ver='IPv4'):
+    """Check if we can connect to the given server"""
+    try:
+        connection = socket.create_connection((server_ip, 443), timeout=2)
+    except OSError:
+        logging.info(
+            'Skipping %s protocol version, no network configuration' % ip_ver
+            )
+        return False
+
+    connection.close()
+    return True
+
+
+# ----------------------------------------------------------------------------
 def has_rmt_ipv6_access(smt):
     """IPv6 access is possible if we have an SMT server that has an IPv6
        address and it can be accessed over IPv6"""
@@ -2077,26 +2092,13 @@ def write_framework_identifier(cfg):
 # ----------------------------------------------------------------------------
 def has_ipv4_access():
     """Check if we have IPv4 network configuration"""
-    return has_network_access_by_ip_address('8.8.8.8')
+    return has_network_access_by_ip_address('8.8.8.8', 'IPv4')
 
 
 # ----------------------------------------------------------------------------
 def has_ipv6_access():
     """Check if we have IPv6 network configuration"""
-    return has_network_access_by_ip_address('2001:4860:4860::8888')
-
-
-# ----------------------------------------------------------------------------
-def has_network_access_by_ip_address(server_ip):
-    """Check if we can connect to the given server"""
-    try:
-        connection = socket.create_connection((server_ip, 443), timeout=2)
-    except OSError as e:
-        logging.info('Network access error: "%s"', e)
-        return False
-
-    connection.close()
-    return True
+    return has_network_access_by_ip_address('2001:4860:4860::8888', 'IPv6')
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -3247,6 +3247,20 @@ def test_has_network_access_by_ip_address(mock_socket_create_connection):
 
 
 # ---------------------------------------------------------------------------
+@patch('cloudregister.registerutils.logging')
+@patch('cloudregister.registerutils.socket.create_connection')
+def test_has_network_access_by_ip_address_no_connection(
+        mock_socket_create_connection, mock_logging
+        ):
+    mock_socket_create_connection.side_effect = OSError
+    has_access = utils.has_network_access_by_ip_address('FFF::0', 'IPv6')
+    assert not has_access
+    assert mock_logging.info.called_once_with(
+        'Skipping IPv6 protocol version, no network configuration'
+    )
+
+
+# ---------------------------------------------------------------------------
 @patch('cloudregister.registerutils.set_registries_conf')
 @patch('cloudregister.registerutils.set_container_engines_env_vars')
 @patch('cloudregister.registerutils.os.path.exists')

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -196,7 +196,6 @@ def register_modules(extensions, products, registered=[], failed=[]):
                 registration_target=registration_target,
                 product=triplet,
                 instance_data_filepath=instance_data_filepath
-                if os.path.exists(instance_data_filepath) else ''
             )
 
             if suseconnect.returncode:
@@ -676,9 +675,12 @@ if registration_smt:
             sys.exit(1)
 
 # Check if we need to send along any instance data
-instance_data_filepath = os.path.join(utils.get_state_dir(), str(uuid.uuid4()))
+instance_data_filepath = ''
 instance_data = utils.get_instance_data(cfg)
 if instance_data:
+    instance_data_filepath = os.path.join(
+        utils.get_state_dir(), str(uuid.uuid4())
+    )
     inst_data_out = open(instance_data_filepath, 'w')
     inst_data_out.write(instance_data)
     inst_data_out.close()
@@ -749,7 +751,6 @@ while not base_registered:
         email=args.email,
         regcode=args.reg_code,
         instance_data_filepath=instance_data_filepath
-        if os.path.exists(instance_data_filepath) else ''
     )
     if suseconnect.returncode:
         registration_returncode = suseconnect.returncode

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -459,8 +459,11 @@ if args.user_smt_ip or args.user_smt_fqdn or args.user_smt_fp:
         print(msg, file=sys.stderr)
         sys.exit(1)
 
+    ip_addr_version = 'IPv4'
     try:
-        ipaddress.ip_address(args.user_smt_ip)
+        ip_addr = ipaddress.ip_address(args.user_smt_ip)
+        if isinstance(ip_addr, ipaddress.IPv6Address):
+            ip_addr_version = 'IPv6'
     except ValueError as err:
         msg = "--smt-ip value '{ip_addr}' is not correct: {err}".format(
             ip_addr=args.user_smt_ip,
@@ -469,13 +472,16 @@ if args.user_smt_ip or args.user_smt_fqdn or args.user_smt_fp:
         print(msg, file=sys.stderr)
         sys.exit(1)
 
-    if not utils.has_network_access_by_ip_address(args.user_smt_ip):
+    if not utils.has_network_access_by_ip_address(
+            args.user_smt_ip, ip_addr_version
+    ):
         error_message = (
             'Connection error: Could not establish a connection to {ip}.'
             'Please, make sure the network configuration supports the '
             'provided {ip} address version.'.format(ip=args.user_smt_ip)
         )
-        sys.exit(error_message)
+        print(error_message, file=sys.stderr)
+        sys.exit(1)
 
 
 if args.clean_up and args.force_new_registration:


### PR DESCRIPTION
Do not check for the instance metadata file at the point of call, this is already handled by the function implementation.
    
Only create the instance metadata file if we have instance metadata to write,
 this ensures we do not create an empty file that then gets passed to
    downstream invocations hoping that the downstream code copes properly
    with an empty file.