### PR TITLE
Remove superfluous condition

### DIFF
--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -196,7 +196,6 @@ def register_modules(extensions, products, registered=[], failed=[]):
                 registration_target=registration_target,
                 product=triplet,
                 instance_data_filepath=instance_data_filepath
-                if os.path.exists(instance_data_filepath) else ''
             )
 
             if suseconnect.returncode:
@@ -670,9 +669,12 @@ if registration_smt:
             sys.exit(1)
 
 # Check if we need to send along any instance data
-instance_data_filepath = os.path.join(utils.get_state_dir(), str(uuid.uuid4()))
+instance_data_filepath = ''
 instance_data = utils.get_instance_data(cfg)
 if instance_data:
+    instance_data_filepath = os.path.join(
+        utils.get_state_dir(), str(uuid.uuid4())
+    )
     inst_data_out = open(instance_data_filepath, 'w')
     inst_data_out.write(instance_data)
     inst_data_out.close()
@@ -743,7 +745,6 @@ while not base_registered:
         email=args.email,
         regcode=args.reg_code,
         instance_data_filepath=instance_data_filepath
-        if os.path.exists(instance_data_filepath) else ''
     )
     if suseconnect.returncode:
         registration_returncode = suseconnect.returncode


### PR DESCRIPTION
Do not check for the instance metadata file at the point of call, this is already handled by the function implementation.

Only create the instance metadata file if we have instance metadata to write, this ensures we do not create an empty file that then gets passed to downstream invocations hoping that the downstream code copes properly with an empty file.