### PR TITLE
package build update

### DIFF
--- a/fix-for-sles12-no-trans_update.patch
+++ b/fix-for-sles12-no-trans_update.patch
@@ -1,0 +1,10 @@
+--- usr/sbin/registercloudguest.orig
++++ usr/sbin/registercloudguest
+@@ -62,6 +62,7 @@ def get_register_cmd():
+     """Determine which command we need to use to register the system"""
+ 
+     register_cmd = '/usr/sbin/SUSEConnect'
++    return register_cmd
+     # Figure out if we are on RO transactional-update system
+     p = subprocess.Popen(
+         ['findmnt', '--noheadings', '--json', '/'],


### PR DESCRIPTION
- The way Python is being built has changed for SUSE distributions. Python 3.6 is, by design no longer available in products SLE Micro and later. We need to use macros that are defined in the build service to pick up the interpreter we want to use for building our code and to find the proper Python module packages we depend on.
- Add a previoulsy forgotten patch for the SLE 12 build that we need to maintain until the EOL of that code stream.