### PR TITLE
Registercloudguest coverage

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -1833,6 +1833,7 @@ def set_proxy():
         proxy_config = pc_file.readlines()
     http_proxy = ''
     https_proxy = ''
+    no_proxy = ''
     for entry in proxy_config:
         if 'PROXY_ENABLED' in entry and 'no' in entry:
             return False

--- a/tests/test_registercloudguest.py
+++ b/tests/test_registercloudguest.py
@@ -1,0 +1,2789 @@
+import inspect
+import json
+import os
+import requests
+
+from collections import namedtuple
+from importlib.machinery import SourceFileLoader
+from lxml import etree
+from textwrap import dedent
+from urllib.parse import ParseResult
+
+from pytest import raises
+from types import SimpleNamespace
+# from unittest import mock
+from unittest.mock import patch, call, Mock, mock_open
+
+test_path = os.path.abspath(
+   os.path.dirname(inspect.getfile(inspect.currentframe())))
+code_path = os.path.abspath('%s/../lib' % test_path)
+data_path = test_path + os.sep + 'data/'
+
+from cloudregister.smt import SMT # noqa
+import cloudregister.registerutils as utils # noqa
+
+# Hack to get the script without the .py imported for testing
+register_cloud_guest = SourceFileLoader(
+    'register_cloud_guest',
+    './usr/sbin/registercloudguest'
+).load_module()
+
+
+def test_register_cloud_guest_missing_param():
+    fake_args = SimpleNamespace(
+        user_smt_ip='fc00::1',
+        user_smt_fqdn='foo.susecloud.net',
+        user_smt_fp=None
+    )
+    with raises(SystemExit):
+        assert register_cloud_guest.main(fake_args) is None
+
+
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+def test_register_cloud_guest_no_connection_ip(mock_has_network):
+    mock_has_network.return_value = False
+    fake_args = SimpleNamespace(
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD'
+    )
+    with raises(SystemExit):
+        assert register_cloud_guest.main(fake_args) is None
+
+
+def test_register_cloud_guest_non_ip_value():
+    fake_args = SimpleNamespace(
+        user_smt_ip='Not.an.IP.Address',
+        user_smt_fqdn='foo.susecloud.net',
+        user_smt_fp='AA:BB:CC'
+    )
+    with raises(SystemExit):
+        assert register_cloud_guest.main(fake_args) is None
+
+
+def test_register_cloud_guest_mixed_param():
+    fake_args = SimpleNamespace(
+        clean_up=True,
+        force_new_registration=True,
+        user_smt_ip=None,
+        user_smt_fqdn=None,
+        user_smt_fp=None
+    )
+    with raises(SystemExit):
+        assert register_cloud_guest.main(fake_args) is None
+
+
+def test_register_cloud_guest_no_regcode_email():
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=False,
+        user_smt_ip=None,
+        user_smt_fqdn=None,
+        user_smt_fp=None,
+        email='foo',
+        reg_code=None
+    )
+    with raises(SystemExit):
+        assert register_cloud_guest.main(fake_args) is None
+
+
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_config')
+@patch('cloudregister.registerutils.clean_framework_identifier')
+@patch('cloudregister.registerutils.clear_new_registration_flag')
+@patch('cloudregister.registerutils.clean_smt_cache')
+@patch('cloudregister.registerutils.remove_registration_data')
+@patch('cloudregister.registerutils.clean_registry_setup')
+def test_register_cloud_guest_cleanup(
+    mock_clean_reg_setup, mock_remove_reg_data, mock_clean_smt_cache,
+    mock_clear_reg_flag, mock_framework_id,  mock_get_config, mock_time_sleep
+):
+    fake_args = SimpleNamespace(
+        clean_up=True,
+        force_new_registration=False,
+        user_smt_ip=None,
+        user_smt_fqdn=None,
+        user_smt_fp=None,
+        email=None,
+        reg_code=None,
+        delay_time=1,
+        config_file='config_file'
+    )
+    with raises(SystemExit):
+        register_cloud_guest.main(fake_args)
+    mock_clean_reg_setup.assert_called_once()
+
+
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.clear_new_registration_flag')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_reg_zypper_runnning(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_clear_reg_flag,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag
+):
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code=None,
+        delay_time=1,
+        config_file='config_file'
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = True
+    mock_get_available_smt_servers.return_value = ['some', 'smt', 'servers']
+    mock_has_network_access.return_value = True
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+    assert sys_exit.value.code == 1
+
+
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_reg_zypper_runnning_write_config(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag
+):
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code=None,
+        delay_time=1,
+        config_file='config_file'
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = True
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+    assert sys_exit.value.code == 1
+
+
+@patch('register_cloud_guest.logging')
+@patch.object(SMT, 'is_equivalent')
+@patch.object(SMT, 'is_responsive')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_reg_zypper_not_running_region_changed(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_smt_is_responsive, mock_smt_is_equivalent, mock_logging
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code=None,
+        delay_time=1,
+        config_file='config_file'
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = True
+    mock_smt_is_responsive.side_effect = [False, True]
+    mock_smt_is_equivalent.return_value = False
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+    assert sys_exit.value.code == 1
+    assert mock_logging.error.call_args_list == [
+        call(
+            'Configured update server is unresponsive. Could not find '
+            'a replacement update server in this region. '
+            'Possible network configuration issue'
+        )
+    ]
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_reg_zypper_not_running_region_not_changed(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = True
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_os_path_exists.return_value = True
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+        assert sys_exit.value.code == 0
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_region_not_changed_proxy_ok(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_set_proxy
+):
+    mock_set_proxy.return_value = True
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = True
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_os_path_exists.return_value = True
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+        assert sys_exit.value.code == 0
+
+
+@patch('cloudregister.registerutils.replace_hosts_entry')
+@patch('cloudregister.registerutils.has_rmt_ipv6_access')
+@patch.object(SMT, 'is_equivalent')
+@patch('cloudregister.registerutils.set_proxy')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_region_not_responsive_proxy_ok(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_set_proxy, mock_smt_is_equivalent,
+    mock_has_ipv6_access, mock_replace_hosts_entry
+):
+    mock_set_proxy.return_value = True
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = True
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.side_effect = [False, True]
+    mock_smt_is_equivalent.return_value = True
+    mock_os_path_exists.return_value = True
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_has_ipv6_access.return_value = True
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+        assert sys_exit.value.code == 0
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_reg_rmt_scc_as_proxy(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.side_effect = [False, True]
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_os_path_exists.return_value = True
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+        assert sys_exit.value.code == 0
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('register_cloud_guest.logging')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_reg_no_executable_found(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_logging, mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_os_path_exists.side_effect = [True, False, False]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = False
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+        assert mock_logging.error.call_args_list == [
+            'No registration executable found'
+        ]
+        assert sys_exit.value.code == 1
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('cloudregister.registerutils.is_registration_supported')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_registration_not_supported(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_is_registration_supported, mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_set_proxy.return_value = False
+    mock_os_path_exists.side_effect = [True, False]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = False
+    mock_is_registration_supported.return_value = False
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+    assert sys_exit.value.code == 0
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('cloudregister.registerutils.get_installed_products')
+@patch('register_cloud_guest.logging')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_reg_no_products_installed(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_logging, mock_get_installed_products,
+    mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_set_proxy.return_value = False
+    mock_os_path_exists.side_effect = [True, True]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = True
+    mock_get_installed_products.return_value = None
+    mock_os_path_join.return_value = ''
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+    assert mock_logging.error.call_args_list == [
+        call('No products installed on system')
+    ]
+    assert sys_exit.value.code == 1
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('cloudregister.registerutils.import_smt_cert')
+@patch('cloudregister.registerutils.get_installed_products')
+@patch('register_cloud_guest.logging')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_reg_cert_import_failed(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_logging, mock_get_installed_products,
+    mock_import_smt_cert, mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_set_proxy.return_value = False
+    mock_os_path_exists.side_effect = [True, True]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = True
+    mock_get_installed_products.return_value = 'foo'
+    mock_import_smt_cert.return_value = False
+    mock_os_path_join.return_value = ''
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+    assert sys_exit.value.code == 1
+    assert mock_logging.error.call_args_list == [
+        call('SMT certificate import failed')
+    ]
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('register_cloud_guest.run_SUSEConnect')
+@patch('cloudregister.registerutils.import_smt_cert')
+@patch('cloudregister.registerutils.get_installed_products')
+@patch('register_cloud_guest.logging')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_baseprod_registration_failed(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_logging, mock_get_installed_products,
+    mock_import_smt_cert, mock_run_SUSEConnect, mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_set_proxy.return_value = False
+    mock_os_path_exists.side_effect = [True, True]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = True
+    mock_get_installed_products.return_value = 'foo'
+    mock_import_smt_cert.return_value = True
+    mock_os_path_join.return_value = ''
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    mock_run_SUSEConnect.return_value = suseconnect_type(
+        returncode=67,
+        output='registration code',
+        error='stderr'
+    )
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+    assert mock_logging.error.call_args_list == [
+        call('Baseproduct registration failed'),
+        call('\tregistration code')
+    ]
+    assert sys_exit.value.code == 1
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch.object(SMT, 'is_equivalent')
+@patch('cloudregister.registerutils.is_registration_supported')
+@patch('register_cloud_guest.get_responding_update_server')
+@patch('cloudregister.registerutils.fetch_smt_data')
+@patch('cloudregister.registerutils.remove_registration_data')
+@patch('register_cloud_guest.run_SUSEConnect')
+@patch('cloudregister.registerutils.import_smt_cert')
+@patch('cloudregister.registerutils.get_installed_products')
+@patch('register_cloud_guest.logging')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_baseprod_registration_failed_connection(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_logging, mock_get_installed_products,
+    mock_import_smt_cert, mock_run_SUSEConnect, mock_remove_reg_data,
+    mock_fetch_smt_data, mock_get_responding_update_server,
+    mock_is_reg_supported, mock_is_equivalent, mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_region_data = dedent('''\
+        <regionSMTdata><smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/><smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.6"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/></regionSMTdata>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip=None,
+        user_smt_fqdn=None,
+        user_smt_fp=None,
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = [smt_server, smt_server]
+    mock_get_responding_update_server.return_value = smt_server
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = False
+    mock_is_equivalent.return_value = False
+    mock_set_proxy.return_value = False
+    mock_os_path_exists.side_effect = [True, True]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = True
+    mock_get_installed_products.return_value = 'foo'
+    mock_import_smt_cert.return_value = True
+    mock_os_path_join.return_value = ''
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    mock_run_SUSEConnect.return_value = suseconnect_type(
+        returncode=64,
+        output='some error',
+        error='stderr'
+    )
+    mock_fetch_smt_data.return_value = etree.fromstring(smt_region_data)
+    mock_is_reg_supported.return_value = True
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+    assert mock_logging.error.call_args_list == [
+        call(
+            "Registration with ('1.2.3.5', 'fc00::1') failed. "
+            "Trying ('1.2.3.6', 'fc00::1')"
+        ),
+        call('Baseproduct registration failed'),
+        call('\tsome error')
+    ]
+    assert sys_exit.value.code == 1
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('cloudregister.registerutils.get_credentials_file')
+@patch('cloudregister.registerutils.get_credentials')
+@patch('register_cloud_guest.get_product_tree')
+@patch('cloudregister.registerutils.requests.get')
+@patch('cloudregister.registerutils.set_rmt_as_scc_proxy_flag')
+@patch('register_cloud_guest.run_SUSEConnect')
+@patch('cloudregister.registerutils.import_smt_cert')
+@patch('cloudregister.registerutils.get_installed_products')
+@patch('register_cloud_guest.logging')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_baseprod_registration_ok_failed_extensions(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_logging, mock_get_installed_products,
+    mock_import_smt_cert, mock_run_SUSEConnect, mock_set_rmt_as_scc_proxy_flag,
+    mock_requests_get, mock_get_product_tree, mock_get_creds,
+    mock_get_creds_file, mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_os_path_exists.side_effect = [True, True]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = True
+    mock_get_installed_products.return_value = 'foo'
+    mock_import_smt_cert.return_value = True
+    mock_os_path_join.return_value = ''
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    mock_run_SUSEConnect.return_value = suseconnect_type(
+        returncode=0,
+        output='registration code',
+        error='stderr'
+    )
+    response = Response()
+    response.status_code = requests.codes.forbidden
+    response.reason = 'Because nope'
+    response.content = str(json.dumps('no accessio')).encode()
+    mock_requests_get.return_value = response
+    mock_get_creds.return_value = 'SCC_foo', 'bar'
+    base_product = dedent('''\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <product schemeversion="0">
+          <vendor>SUSE</vendor>
+          <name>SLES</name>
+          <version>15.4</version>
+          <baseversion>15</baseversion>
+          <patchlevel>4</patchlevel>
+          <release>0</release>
+          <endoflife></endoflife>
+          <arch>x86_64</arch></product>''')
+    mock_get_product_tree.return_value = etree.fromstring(
+        base_product[base_product.index('<product'):]
+    )
+    mock_set_proxy.return_value = False
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+    mock_logging.error.assert_called_once_with(
+        'Unable to obtain product information from server "1.2.3.5,None"'
+        '\n\tBecause nope\n\t"no accessio"\n'
+        'Unable to register modules, exiting.'
+    )
+    assert sys_exit.value.code == 1
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('register_cloud_guest.registration_returncode', 0)
+@patch('register_cloud_guest.os.unlink')
+@patch('cloudregister.registerutils.get_credentials_file')
+@patch('cloudregister.registerutils.get_credentials')
+@patch('register_cloud_guest.get_product_tree')
+@patch('cloudregister.registerutils.requests.get')
+@patch('cloudregister.registerutils.set_rmt_as_scc_proxy_flag')
+@patch('register_cloud_guest.run_SUSEConnect')
+@patch('cloudregister.registerutils.import_smt_cert')
+@patch('cloudregister.registerutils.get_installed_products')
+@patch('register_cloud_guest.logging')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_guest_force_baseprod_extensions_raise(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_logging, mock_get_installed_products,
+    mock_import_smt_cert, mock_run_SUSEConnect,
+    mock_set_rmt_as_scc_proxy_flag,
+    mock_requests_get, mock_get_product_tree, mock_get_creds,
+    mock_get_creds_file, mock_os_unlink, mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_os_path_exists.side_effect = [True, True, True, True]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = True
+    mock_get_installed_products.return_value = 'SLES-LTSS/15.4/x86_64'
+    mock_import_smt_cert.return_value = True
+    mock_os_path_join.return_value = ''
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    mock_run_SUSEConnect.side_effect = [
+        suseconnect_type(
+            returncode=0,
+            output='all OK',
+            error='stderr'
+        ),
+        suseconnect_type(
+            returncode=6,
+            output='registration code',
+            error='stderr'
+        )
+    ]
+    response = Response()
+    response.status_code = requests.codes.ok
+    json_mock = Mock()
+    json_mock.return_value = {
+        'id': 2001,
+        'name': 'SUSE Linux Enterprise Server',
+        'identifier': 'SLES',
+        'former_identifier': 'SLES',
+        'version': '15.4',
+        'release_type': None,
+        'release_stage': 'released',
+        'arch': 'x86_64',
+        'friendly_name': 'SUSE Linux Enterprise Server 15 SP4 x86_64',
+        'product_class': '30',
+        'extensions': [
+            {
+                'id': 23,
+                'name': 'SUSE Linux Enterprise Server LTSS',
+                'identifier': 'SLES-LTSS',
+                'former_identifier': 'SLES-LTSS',
+                'version': '15.4',
+                'release_type': None,
+                'release_stage': 'released',
+                'arch': 'x86_64',
+                'friendly_name':
+                'SUSE Linux Enterprise Server LTSS 15 SP4 x86_64',
+                'product_class': 'SLES15-SP4-LTSS-X86',
+                'free': False,
+                'repositories': [],
+                'product_type': 'extension',
+                'extensions': [],
+                'recommended': False,
+                'available': True
+            }
+        ]
+    }
+    response.json = json_mock
+    mock_requests_get.return_value = response
+    mock_get_creds.return_value = 'SCC_foo', 'bar'
+    base_product = dedent('''\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <product schemeversion="0">
+          <vendor>SUSE</vendor>
+          <name>SLES</name>
+          <version>15.4</version>
+          <baseversion>15</baseversion>
+          <patchlevel>4</patchlevel>
+          <release>0</release>
+          <endoflife></endoflife>
+          <arch>x86_64</arch></product>''')
+    mock_get_product_tree.return_value = etree.fromstring(
+        base_product[base_product.index('<product'):]
+    )
+    mock_set_proxy.return_value = False
+    mock_get_register_cmd.return_value = '/usr/sbin/SUSEConnect'
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.main(fake_args)
+    assert sys_exit.value.code == 6
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('register_cloud_guest.urllib.parse.urlparse')
+@patch('cloudregister.registerutils.enable_repository')
+@patch('cloudregister.registerutils.exec_subprocess')
+@patch('cloudregister.registerutils.get_repo_url')
+@patch('cloudregister.registerutils.find_repos')
+@patch('cloudregister.registerutils.has_nvidia_support')
+@patch('register_cloud_guest.registration_returncode', 0)
+@patch('register_cloud_guest.os.unlink')
+@patch('cloudregister.registerutils.get_credentials_file')
+@patch('cloudregister.registerutils.get_credentials')
+@patch('register_cloud_guest.get_product_tree')
+@patch('cloudregister.registerutils.requests.get')
+@patch('cloudregister.registerutils.set_rmt_as_scc_proxy_flag')
+@patch('register_cloud_guest.run_SUSEConnect')
+@patch('cloudregister.registerutils.import_smt_cert')
+@patch('cloudregister.registerutils.get_installed_products')
+@patch('register_cloud_guest.logging')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_baseprod_registration_ok_extensions_ok_complete(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_logging, mock_get_installed_products,
+    mock_import_smt_cert, mock_run_SUSEConnect,
+    mock_set_rmt_as_scc_proxy_flag,
+    mock_requests_get, mock_get_product_tree, mock_get_creds,
+    mock_get_creds_file, mock_os_unlink, mock_has_nvidia_support,
+    mock_find_repos, mock_get_repo_url, mock_exec_subprocess, mock_enable_repo,
+    mock_urlparse, mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='1.2.3.5',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_os_path_exists.side_effect = [True, True, True, True]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = True
+    mock_get_installed_products.return_value = 'SLES-LTSS/15.4/x86_64'
+    mock_import_smt_cert.return_value = True
+    mock_os_path_join.return_value = ''
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    mock_run_SUSEConnect.side_effect = [
+        suseconnect_type(
+            returncode=0,
+            output='all OK',
+            error='stderr'
+        ),
+        suseconnect_type(
+            returncode=0,
+            output='registration code',
+            error='stderr'
+        )
+    ]
+    response = Response()
+    response.status_code = requests.codes.ok
+    json_mock = Mock()
+    json_mock.return_value = {
+        'id': 2001,
+        'name': 'SUSE Linux Enterprise Server',
+        'identifier': 'SLES',
+        'former_identifier': 'SLES',
+        'version': '15.4',
+        'release_type': None,
+        'release_stage': 'released',
+        'arch': 'x86_64',
+        'friendly_name': 'SUSE Linux Enterprise Server 15 SP4 x86_64',
+        'product_class': '30',
+        'extensions': [
+            {
+                'id': 23,
+                'name': 'SUSE Linux Enterprise Server LTSS',
+                'identifier': 'SLES-LTSS',
+                'former_identifier': 'SLES-LTSS',
+                'version': '15.4',
+                'release_type': None,
+                'release_stage': 'released',
+                'arch': 'x86_64',
+                'friendly_name':
+                'SUSE Linux Enterprise Server LTSS 15 SP4 x86_64',
+                'product_class': 'SLES15-SP4-LTSS-X86',
+                'free': False,
+                'repositories': [],
+                'product_type': 'extension',
+                'extensions': [],
+                'recommended': False,
+                'available': True
+            }
+        ]
+    }
+    response.json = json_mock
+    mock_requests_get.return_value = response
+    mock_get_creds.return_value = 'SCC_foo', 'bar'
+    base_product = dedent('''\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <product schemeversion="0">
+          <vendor>SUSE</vendor>
+          <name>SLES</name>
+          <version>15.4</version>
+          <baseversion>15</baseversion>
+          <patchlevel>4</patchlevel>
+          <release>0</release>
+          <endoflife></endoflife>
+          <arch>x86_64</arch></product>''')
+    mock_get_product_tree.return_value = etree.fromstring(
+        base_product[base_product.index('<product'):]
+    )
+    mock_get_register_cmd.return_value = '/usr/sbin/SUSEConnect'
+    mock_has_nvidia_support.return_value = True
+    mock_find_repos.return_value = ['repo_a', 'repo_b']
+    mock_get_repo_url.return_value = (
+        'plugin:/susecloud?credentials=Basesystem_Module_x86_64&'
+        'path=/repo/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/'
+    )
+    mock_exec_subprocess.side_effect = [True, False]
+    mock_urlparse.return_value = ParseResult(
+        scheme='https', netloc='susecloud.net:443',
+        path='/some/repo', params='',
+        query='highlight=params', fragment='url-parsing'
+    )
+    mock_set_proxy.return_value = False
+    assert register_cloud_guest.main(fake_args) is None
+    assert mock_logging.info.call_args_list == [
+        call('Forced new registration'),
+        call(
+            'Using user specified SMT server:\n\n\t"IP:1.2.3.5"\n\t"'
+            'FQDN:foo-ec2.susecloud.net"\n\t"Fingerprint:AA:BB:CC:DD"'
+        ),
+        call('Region change detected, registering to new servers'),
+        call('Baseproduct registration complete'),
+        call(
+            'Cannot reach host: "susecloud.net", will not enable repo "repo_a"'
+        )
+    ]
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('register_cloud_guest.urllib.parse.urlparse')
+@patch('cloudregister.registerutils.enable_repository')
+@patch('cloudregister.registerutils.exec_subprocess')
+@patch('cloudregister.registerutils.get_repo_url')
+@patch('cloudregister.registerutils.find_repos')
+@patch('cloudregister.registerutils.has_nvidia_support')
+@patch('register_cloud_guest.registration_returncode', 0)
+@patch('register_cloud_guest.os.unlink')
+@patch('cloudregister.registerutils.get_credentials_file')
+@patch('cloudregister.registerutils.get_credentials')
+@patch('register_cloud_guest.get_product_tree')
+@patch('cloudregister.registerutils.requests.get')
+@patch('cloudregister.registerutils.set_rmt_as_scc_proxy_flag')
+@patch('register_cloud_guest.run_SUSEConnect')
+@patch('cloudregister.registerutils.import_smt_cert')
+@patch('cloudregister.registerutils.get_installed_products')
+@patch('register_cloud_guest.logging')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_baseprod_ok_recommended_extensions_ok_complete(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_logging, mock_get_installed_products,
+    mock_import_smt_cert, mock_run_SUSEConnect,
+    mock_set_rmt_as_scc_proxy_flag,
+    mock_requests_get, mock_get_product_tree, mock_get_creds,
+    mock_get_creds_file, mock_os_unlink, mock_has_nvidia_support,
+    mock_find_repos, mock_get_repo_url, mock_exec_subprocess, mock_enable_repo,
+    mock_urlparse, mock_set_proxy
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='fc00::1',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_os_path_exists.side_effect = [True, True, True, True]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = True
+    mock_get_installed_products.return_value = 'SLES-LTSS/15.4/x86_64'
+    mock_import_smt_cert.return_value = True
+    mock_os_path_join.return_value = ''
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    mock_run_SUSEConnect.side_effect = [
+        suseconnect_type(
+            returncode=0,
+            output='all OK',
+            error='stderr'
+        ),
+        suseconnect_type(
+            returncode=0,
+            output='registration code',
+            error='stderr'
+        )
+    ]
+    response = Response()
+    response.status_code = requests.codes.ok
+    json_mock = Mock()
+    json_mock.return_value = {
+        'id': 2001,
+        'name': 'SUSE Linux Enterprise Server',
+        'identifier': 'SLES',
+        'former_identifier': 'SLES',
+        'version': '15.4',
+        'release_type': None,
+        'release_stage': 'released',
+        'arch': 'x86_64',
+        'friendly_name': 'SUSE Linux Enterprise Server 15 SP4 x86_64',
+        'product_class': '30',
+        'extensions': [
+            {
+                'id': 23,
+                'name': 'SUSE Linux Enterprise Server LTSS',
+                'identifier': 'SLES-LTSS',
+                'former_identifier': 'SLES-LTSS',
+                'version': '15.4',
+                'release_type': None,
+                'release_stage': 'released',
+                'arch': 'x86_64',
+                'friendly_name':
+                'SUSE Linux Enterprise Server LTSS 15 SP4 x86_64',
+                'product_class': 'SLES15-SP4-LTSS-X86',
+                'free': False,
+                'repositories': [],
+                'product_type': 'extension',
+                'extensions': [],
+                'recommended': True,
+                'available': True
+            }
+        ]
+    }
+    response.json = json_mock
+    mock_requests_get.return_value = response
+    mock_get_creds.return_value = 'SCC_foo', 'bar'
+    base_product = dedent('''\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <product schemeversion="0">
+          <vendor>SUSE</vendor>
+          <name>SLES</name>
+          <version>15.4</version>
+          <baseversion>15</baseversion>
+          <patchlevel>4</patchlevel>
+          <release>0</release>
+          <endoflife></endoflife>
+          <arch>x86_64</arch></product>''')
+    mock_get_product_tree.return_value = etree.fromstring(
+        base_product[base_product.index('<product'):]
+    )
+    mock_get_register_cmd.return_value = '/usr/sbin/SUSEConnect'
+    mock_has_nvidia_support.return_value = True
+    mock_find_repos.return_value = ['repo_a', 'repo_b']
+    mock_get_repo_url.return_value = (
+        'plugin:/susecloud?credentials=Basesystem_Module_x86_64&'
+        'path=/repo/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/'
+    )
+    mock_exec_subprocess.side_effect = [True, False]
+    mock_urlparse.return_value = ParseResult(
+        scheme='https', netloc='susecloud.net:443',
+        path='/some/repo', params='',
+        query='highlight=params', fragment='url-parsing'
+    )
+    mock_set_proxy.return_value = False
+    assert register_cloud_guest.main(fake_args) is None
+    assert mock_logging.info.call_args_list == [
+        call('Forced new registration'),
+        call(
+            'Using user specified SMT server:\n\n\t"IP:fc00::1"\n\t"'
+            'FQDN:foo-ec2.susecloud.net"\n\t"Fingerprint:AA:BB:CC:DD"'
+        ),
+        call('Region change detected, registering to new servers'),
+        call('Baseproduct registration complete'),
+        call(
+            'Cannot reach host: "susecloud.net", will not enable repo "repo_a"'
+        )
+    ]
+
+
+@patch('register_cloud_guest.os.system')
+@patch('cloudregister.registerutils.set_proxy')
+@patch('builtins.print')
+@patch('register_cloud_guest.urllib.parse.urlparse')
+@patch('cloudregister.registerutils.enable_repository')
+@patch('cloudregister.registerutils.exec_subprocess')
+@patch('cloudregister.registerutils.get_repo_url')
+@patch('cloudregister.registerutils.find_repos')
+@patch('cloudregister.registerutils.has_nvidia_support')
+@patch('register_cloud_guest.registration_returncode', 0)
+@patch('register_cloud_guest.os.unlink')
+@patch('cloudregister.registerutils.get_credentials_file')
+@patch('cloudregister.registerutils.get_credentials')
+@patch('register_cloud_guest.get_product_tree')
+@patch('cloudregister.registerutils.requests.get')
+@patch('cloudregister.registerutils.set_rmt_as_scc_proxy_flag')
+@patch('register_cloud_guest.run_SUSEConnect')
+@patch('cloudregister.registerutils.import_smt_cert')
+@patch('cloudregister.registerutils.get_installed_products')
+@patch('register_cloud_guest.logging')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_baseprod_ok_recommended_extensions_failed(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_logging, mock_get_installed_products,
+    mock_import_smt_cert, mock_run_SUSEConnect,
+    mock_set_rmt_as_scc_proxy_flag,
+    mock_requests_get, mock_get_product_tree, mock_get_creds,
+    mock_get_creds_file, mock_os_unlink, mock_has_nvidia_support,
+    mock_find_repos, mock_get_repo_url, mock_exec_subprocess, mock_enable_repo,
+    mock_urlparse, mock_print, mock_set_proxy, mock_os_system
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        user_smt_ip='fc00::1',
+        user_smt_fqdn='foo-ec2.susecloud.net',
+        user_smt_fp='AA:BB:CC:DD',
+        email=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = None
+    mock_smt_is_responsive.return_value = True
+    mock_os_path_exists.side_effect = [False, True, True, True]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = True
+    mock_get_installed_products.return_value = 'SLES-LTSS-FOO/15.4/x86_64'
+    mock_import_smt_cert.return_value = True
+    mock_os_path_join.return_value = ''
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    mock_run_SUSEConnect.side_effect = [
+        suseconnect_type(
+            returncode=0,
+            output='all OK',
+            error='stderr'
+        ),
+        suseconnect_type(
+            returncode=67,
+            output='registration code',
+            error='stderr'
+        )
+    ]
+    response = Response()
+    response.status_code = requests.codes.ok
+    json_mock = Mock()
+    json_mock.return_value = {
+        'id': 2001,
+        'name': 'SUSE Linux Enterprise Server',
+        'identifier': 'SLES',
+        'former_identifier': 'SLES',
+        'version': '15.4',
+        'release_type': None,
+        'release_stage': 'released',
+        'arch': 'x86_64',
+        'friendly_name': 'SUSE Linux Enterprise Server 15 SP4 x86_64',
+        'product_class': '30',
+        'extensions': [
+            {
+                'id': 23,
+                'name': 'SUSE Linux Enterprise Server LTSS Foo',
+                'identifier': 'SLES-LTSS-FOO',
+                'former_identifier': 'SLES-LTSS-FOO',
+                'version': '15.4',
+                'release_type': None,
+                'release_stage': 'released',
+                'arch': 'x86_64',
+                'friendly_name':
+                'SUSE Linux Enterprise Server LTSS 15 SP4 x86_64',
+                'product_class': 'SLES15-SP4-LTSS-FOO-X86',
+                'free': False,
+                'repositories': [],
+                'product_type': 'extension',
+                'extensions': [],
+                'recommended': False,
+                'available': True
+            }
+        ]
+    }
+    response.json = json_mock
+    mock_requests_get.return_value = response
+    mock_get_creds.return_value = 'SCC_foo', 'bar'
+    base_product = dedent('''\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <product schemeversion="0">
+          <vendor>SUSE</vendor>
+          <name>SLES</name>
+          <version>15.4</version>
+          <baseversion>15</baseversion>
+          <patchlevel>4</patchlevel>
+          <release>0</release>
+          <endoflife></endoflife>
+          <arch>x86_64</arch></product>''')
+    mock_get_product_tree.return_value = etree.fromstring(
+        base_product[base_product.index('<product'):]
+    )
+    mock_get_register_cmd.return_value = '/usr/sbin/SUSEConnect'
+    mock_has_nvidia_support.return_value = False
+    mock_find_repos.return_value = ['repo_a', 'repo_b']
+    mock_get_repo_url.return_value = (
+        'plugin:/susecloud?credentials=Basesystem_Module_x86_64&'
+        'path=/repo/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/'
+    )
+    mock_exec_subprocess.side_effect = [True, False]
+    mock_urlparse.return_value = ParseResult(
+        scheme='https', netloc='susecloud.net:443',
+        path='/some/repo', params='',
+        query='highlight=params', fragment='url-parsing'
+    )
+    mock_set_proxy.return_value = False
+    assert register_cloud_guest.main(fake_args) is None
+    assert mock_print.call_args_list == [
+        call('Registration succeeded'),
+        call(
+            'There are products that were not registered '
+            'because they need an additional registration code, '
+            'to register them please run the following command:'
+        ),
+        call('SUSEConnect -p SLES-LTSS-FOO/15.4/x86_64 -r ADDITIONAL REGCODE')
+    ]
+
+
+@patch('cloudregister.registerutils.set_proxy')
+@patch('register_cloud_guest.get_responding_update_server')
+@patch('cloudregister.registerutils.is_registration_supported')
+@patch('cloudregister.registerutils.fetch_smt_data')
+@patch('register_cloud_guest.urllib.parse.urlparse')
+@patch('cloudregister.registerutils.enable_repository')
+@patch('cloudregister.registerutils.exec_subprocess')
+@patch('cloudregister.registerutils.get_repo_url')
+@patch('cloudregister.registerutils.find_repos')
+@patch('cloudregister.registerutils.has_nvidia_support')
+@patch('register_cloud_guest.registration_returncode', 0)
+@patch('register_cloud_guest.os.unlink')
+@patch('cloudregister.registerutils.get_credentials_file')
+@patch('cloudregister.registerutils.get_credentials')
+@patch('register_cloud_guest.get_product_tree')
+@patch('cloudregister.registerutils.requests.get')
+@patch('cloudregister.registerutils.set_rmt_as_scc_proxy_flag')
+@patch('register_cloud_guest.run_SUSEConnect')
+@patch('cloudregister.registerutils.import_smt_cert')
+@patch('cloudregister.registerutils.get_installed_products')
+@patch('register_cloud_guest.logging')
+@patch('cloudregister.registerutils.set_as_current_smt')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.get_register_cmd')
+@patch('cloudregister.registerutils.update_rmt_cert')
+@patch('cloudregister.registerutils.has_registry_in_hosts')
+@patch('cloudregister.registerutils.add_hosts_entry')
+@patch('cloudregister.registerutils.clean_hosts_file')
+@patch('cloudregister.registerutils.has_rmt_in_hosts')
+@patch('cloudregister.registerutils.os.path.exists')
+@patch.object(SMT, 'is_responsive')
+@patch('register_cloud_guest.setup_ltss_registration')
+@patch('register_cloud_guest.setup_registry')
+@patch('cloudregister.registerutils.get_instance_data')
+@patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+@patch('cloudregister.registerutils.has_region_changed')
+@patch('cloudregister.registerutils.os.path.join')
+@patch('cloudregister.registerutils.store_smt_data')
+@patch('cloudregister.registerutils.get_current_smt')
+@patch('cloudregister.registerutils.set_new_registration_flag')
+@patch('cloudregister.registerutils.has_network_access_by_ip_address')
+@patch('cloudregister.registerutils.is_zypper_running')
+@patch('cloudregister.registerutils.write_framework_identifier')
+@patch('cloudregister.registerutils.get_available_smt_servers')
+@patch('register_cloud_guest.os.makedirs')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.time.sleep')
+@patch('cloudregister.registerutils.get_state_dir')
+@patch('cloudregister.registerutils.get_config')
+@patch('register_cloud_guest.cleanup')
+def test_register_cloud_baseprod_ok_recommended_extensions_ok_complete_no_ip(
+    mock_cleanup, mock_get_config,
+    mock_get_state_dir, mock_time_sleep,
+    mock_os_path_isdir, mock_os_makedirs,
+    mock_get_available_smt_servers, mock_write_framework_id,
+    mock_is_zypper_running, mock_has_network_access,
+    mock_set_new_registration_flag, mock_get_current_smt,
+    mock_store_smt_data, mock_os_path_join,
+    mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+    mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+    mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+    mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+    mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+    mock_set_as_current_smt, mock_logging, mock_get_installed_products,
+    mock_import_smt_cert, mock_run_SUSEConnect,
+    mock_set_rmt_as_scc_proxy_flag,
+    mock_requests_get, mock_get_product_tree, mock_get_creds,
+    mock_get_creds_file, mock_os_unlink, mock_has_nvidia_support,
+    mock_find_repos, mock_get_repo_url, mock_exec_subprocess, mock_enable_repo,
+    mock_urlparse, mock_fetch_smt_data,
+    mock_is_reg_supported, mock_get_responding_update_server, mock_set_proxy
+):
+    mock_set_proxy.return_value = False
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_fetch_smt_data.return_value = etree.fromstring(smt_data_ipv46)
+    mock_get_current_smt.return_value = smt_server
+    fake_args = SimpleNamespace(
+        clean_up=False,
+        force_new_registration=True,
+        email=None,
+        user_smt_ip=None,
+        user_smt_fqdn=None,
+        user_smt_fp=None,
+        reg_code='super_reg_code',
+        delay_time=1,
+        config_file='config_file',
+    )
+    mock_is_reg_supported.return_value = False
+    mock_os_path_isdir.return_value = False
+    mock_is_zypper_running.return_value = False
+    mock_get_available_smt_servers.return_value = []
+    mock_has_network_access.return_value = True
+    mock_has_region_changed.return_value = True
+    mock_uses_rmt_as_scc_proxy.return_value = False
+    mock_get_instance_data.return_value = True
+    mock_smt_is_responsive.return_value = True
+    mock_os_path_exists.side_effect = [True, False, True, True, True]
+    mock_update_rmt_cert.return_value = True
+    mock_has_rmt_in_hosts.return_value = False
+    mock_has_registry_in_hosts.return_value = False
+    mock_os_access.return_value = True
+    mock_get_installed_products.return_value = 'SLES-LTSS/15.4/x86_64'
+    mock_import_smt_cert.return_value = True
+    mock_os_path_join.return_value = ''
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    mock_run_SUSEConnect.side_effect = [
+        suseconnect_type(
+            returncode=0,
+            output='all OK',
+            error='stderr'
+        ),
+        suseconnect_type(
+            returncode=0,
+            output='registration code',
+            error='stderr'
+        )
+    ]
+    response = Response()
+    response.status_code = requests.codes.ok
+    json_mock = Mock()
+    json_mock.return_value = {
+        'id': 2001,
+        'name': 'SUSE Linux Enterprise Server',
+        'identifier': 'SLES',
+        'former_identifier': 'SLES',
+        'version': '15.4',
+        'release_type': None,
+        'release_stage': 'released',
+        'arch': 'x86_64',
+        'friendly_name': 'SUSE Linux Enterprise Server 15 SP4 x86_64',
+        'product_class': '30',
+        'extensions': [
+            {
+                'id': 23,
+                'name': 'SUSE Linux Enterprise Server LTSS',
+                'identifier': 'SLES-LTSS',
+                'former_identifier': 'SLES-LTSS',
+                'version': '15.4',
+                'release_type': None,
+                'release_stage': 'released',
+                'arch': 'x86_64',
+                'friendly_name':
+                'SUSE Linux Enterprise Server LTSS 15 SP4 x86_64',
+                'product_class': 'SLES15-SP4-LTSS-X86',
+                'free': False,
+                'repositories': [],
+                'product_type': 'extension',
+                'extensions': [],
+                'recommended': True,
+                'available': True
+            }
+        ]
+    }
+    response.json = json_mock
+    mock_requests_get.return_value = response
+    mock_get_creds.return_value = 'SCC_foo', 'bar'
+    base_product = dedent('''\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <product schemeversion="0">
+          <vendor>SUSE</vendor>
+          <name>SLES</name>
+          <version>15.4</version>
+          <baseversion>15</baseversion>
+          <patchlevel>4</patchlevel>
+          <release>0</release>
+          <endoflife></endoflife>
+          <arch>x86_64</arch></product>''')
+    mock_get_product_tree.return_value = etree.fromstring(
+        base_product[base_product.index('<product'):]
+    )
+    mock_get_register_cmd.return_value = '/usr/sbin/SUSEConnect'
+    mock_has_nvidia_support.return_value = True
+    mock_find_repos.return_value = ['repo_a', 'repo_b']
+    mock_get_repo_url.return_value = (
+        'plugin:/susecloud?credentials=Basesystem_Module_x86_64&'
+        'path=/repo/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/'
+    )
+    mock_exec_subprocess.side_effect = [True, False]
+    mock_urlparse.return_value = ParseResult(
+        scheme='https', netloc='susecloud.net:443',
+        path='/some/repo', params='',
+        query='highlight=params', fragment='url-parsing'
+    )
+    with raises(SystemExit) as sys_exit:
+        with patch('builtins.open', mock_open()):
+            register_cloud_guest.main(fake_args)
+    assert sys_exit.value.code == 0
+    assert mock_logging.info.call_args_list == [
+        call('Forced new registration'),
+        call('Region change detected, registering to new servers')
+    ]
+
+
+@patch('register_cloud_guest.logging')
+@patch('register_cloud_guest.subprocess.Popen')
+def test_get_register_cmd_error(mock_popen, mock_logging):
+    mock_process = Mock()
+    mock_process.communicate = Mock(
+        return_value=[str.encode(''), str.encode('')]
+    )
+    mock_process.returncode = 1
+    mock_popen.return_value = mock_process
+    assert register_cloud_guest.get_register_cmd() == '/usr/sbin/SUSEConnect'
+    assert mock_logging.warning.call_args_list == [
+        call('Unable to find filesystem information for "/"')
+    ]
+
+
+@patch('register_cloud_guest.os.path.exists')
+@patch('register_cloud_guest.json.loads')
+@patch('register_cloud_guest.logging')
+@patch('register_cloud_guest.subprocess.Popen')
+def test_get_register_cmd_path_not_exist(
+    mock_popen, mock_logging, mock_json_loads, mock_os_path_exists
+):
+    mock_process = Mock()
+    mock_process.communicate = Mock(
+        return_value=[str.encode(''), str.encode('')]
+    )
+    mock_process.returncode = 0
+    mock_popen.return_value = mock_process
+    mock_json_loads.return_value = {
+        'filesystems': [
+            {
+                'target': '/',
+                'source': '/dev/xvda3',
+                'fstype': 'xfs',
+                'options':
+                'ro,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota'
+            }
+        ]
+    }
+    mock_os_path_exists.return_value = False
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.get_register_cmd()
+    assert sys_exit.value.code == 1
+    assert mock_logging.error.call_args_list == [
+        call(
+            'transactional-update command not found.But is required on a RO '
+            'filesystem for registration'
+        )
+    ]
+
+
+@patch('register_cloud_guest.os.path.exists')
+@patch('register_cloud_guest.json.loads')
+@patch('register_cloud_guest.subprocess.Popen')
+def test_get_register_cmd_ok(
+    mock_popen, mock_json_loads, mock_os_path_exists
+):
+    mock_process = Mock()
+    mock_process.communicate = Mock(
+        return_value=[str.encode(''), str.encode('')]
+    )
+    mock_process.returncode = 0
+    mock_popen.return_value = mock_process
+    mock_json_loads.return_value = {
+        'filesystems': [
+            {
+                'target': '/',
+                'source': '/dev/xvda3',
+                'fstype': 'xfs',
+                'options':
+                'ro,relatime,attr2,inode64,logbufs=8,logbsize=32k,noquota'
+            }
+        ]
+    }
+    mock_os_path_exists.return_value = True
+    assert register_cloud_guest.get_register_cmd() == \
+        '/sbin/transactional-update'
+
+
+@patch('register_cloud_guest.get_register_cmd')
+@patch('register_cloud_guest.logging')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.os.path.exists')
+@patch('register_cloud_guest.subprocess.Popen')
+def test_run_SUSEConnect_no_exists(
+    mock_popen, mock_os_path_exists,
+    mock_os_access, mock_logging,
+    mock_get_register_cmd
+):
+    mock_os_path_exists.return_value = False
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.run_SUSEConnect('foo')
+    assert sys_exit.value.code == 1
+    assert mock_logging.error.call_args_list == [
+        call('No registration executable found')
+    ]
+
+
+@patch('register_cloud_guest.get_register_cmd')
+@patch('register_cloud_guest.logging')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.os.path.exists')
+@patch('register_cloud_guest.subprocess.Popen')
+def test_run_SUSEConnect_no_transactional_ok(
+    mock_popen, mock_os_path_exists,
+    mock_os_access, mock_logging,
+    mock_get_register_cmd
+):
+    mock_os_path_exists.return_value = True
+    mock_os_access.return_value = True
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_register_cmd.return_value = '/usr/sbin/SUSEConnect'
+    expected_cmd = (
+        'Registration: '
+        '/usr/sbin/SUSEConnect '
+        '--url https://foo-ec2.susecloud.net '
+        '--product product '
+        '--instance-data instance_data_filepath '
+        '--email email '
+        '--regcode XXXX'
+    )
+    mock_process = Mock()
+    mock_process.communicate = Mock(
+        return_value=[str.encode('OK'), str.encode('not_OK')]
+    )
+    mock_process.returncode = 0
+    mock_popen.return_value = mock_process
+    result = register_cloud_guest.run_SUSEConnect(
+        smt_server, 'reg_code', 'email', 'instance_data_filepath', 'product'
+    )
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    assert result == suseconnect_type(
+        returncode=0,
+        output='OK',
+        error='not_OK'
+    )
+    assert mock_logging.info.call_args_list == [call(expected_cmd)]
+
+
+@patch('register_cloud_guest.get_register_cmd')
+@patch('register_cloud_guest.logging')
+@patch('register_cloud_guest.os.access')
+@patch('register_cloud_guest.os.path.exists')
+@patch('register_cloud_guest.subprocess.Popen')
+def test_run_SUSEConnect_transactional_ok(
+    mock_popen, mock_os_path_exists,
+    mock_os_access, mock_logging,
+    mock_get_register_cmd
+):
+    mock_os_path_exists.return_value = True
+    mock_os_access.return_value = True
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_register_cmd.return_value = '/usr/sbin/transactional'
+    expected_cmd = (
+        'Registration: '
+        '/usr/sbin/transactional '
+        'register --url https://foo-ec2.susecloud.net '
+        '--product product '
+        '--instance-data instance_data_filepath '
+        '--email email '
+        '--regcode XXXX'
+    )
+    mock_process = Mock()
+    mock_process.communicate = Mock(
+        return_value=[str.encode('OK'), str.encode('not_OK')]
+    )
+    mock_process.returncode = 0
+    mock_popen.return_value = mock_process
+    result = register_cloud_guest.run_SUSEConnect(
+        smt_server, 'reg_code', 'email', 'instance_data_filepath', 'product'
+    )
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    assert result == suseconnect_type(
+        returncode=0,
+        output='OK',
+        error='not_OK'
+    )
+    assert mock_logging.info.call_args_list == [call(expected_cmd)]
+
+
+@patch('register_cloud_guest.run_SUSEConnect')
+def test_register_modules(mock_run_SUSEConnect):
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+
+    mock_run_SUSEConnect.return_value = suseconnect_type(
+        returncode=67,
+        output='registration code',
+        error='stderr'
+    )
+    extensions = [
+        {
+            'id': 23,
+            'name': 'SUSE Linux Enterprise Server LTSS',
+            'identifier': 'SLES-LTSS',
+            'former_identifier': 'SLES-LTSS',
+            'version': '15.4',
+            'release_type': None,
+            'release_stage': 'released',
+            'arch': 'x86_64',
+            'friendly_name':
+            'SUSE Linux Enterprise Server LTSS 15 SP4 x86_64',
+            'product_class': 'SLES15-SP4-LTSS-X86',
+            'free': False,
+            'repositories': [],
+            'product_type': 'extension',
+            'extensions': [],
+            'recommended': False,
+            'available': True
+        }
+    ]
+    register_cloud_guest.register_modules(
+        extensions, ['SLES-LTSS/15.4/x86_64'], 'reg_target', 'path', [], []
+    )
+
+
+@patch('cloudregister.registerutils.is_registry_registered')
+@patch('cloudregister.registerutils.get_credentials_file')
+@patch('cloudregister.registerutils.get_credentials')
+def test_setup_registry_registered(
+    mock_get_credentials, mock_get_credentials_file,
+    mock_is_registry_registered
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_credentials.return_value = 'foo', 'bar'
+    mock_is_registry_registered.return_value = True
+    assert register_cloud_guest.setup_registry(smt_server)
+
+
+@patch('register_cloud_guest.cleanup')
+@patch('cloudregister.registerutils.setup_registry')
+@patch('cloudregister.registerutils.is_registry_registered')
+@patch('cloudregister.registerutils.get_credentials_file')
+@patch('cloudregister.registerutils.get_credentials')
+def test_setup_clean_all(
+    mock_get_credentials, mock_get_credentials_file,
+    mock_is_registry_registered, mock_setup_registry,
+    mock_cleanup
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_credentials.return_value = 'foo', 'bar'
+    mock_is_registry_registered.return_value = False
+    mock_setup_registry.return_value = False
+    with raises(SystemExit) as sys_exit:
+        assert register_cloud_guest.setup_registry(smt_server, 'all')
+    assert sys_exit.value.code == 1
+
+
+@patch('cloudregister.registerutils.clean_registry_setup')
+@patch('cloudregister.registerutils.setup_registry')
+@patch('cloudregister.registerutils.is_registry_registered')
+@patch('cloudregister.registerutils.get_credentials_file')
+@patch('cloudregister.registerutils.get_credentials')
+def test_setup_clean_registry(
+    mock_get_credentials, mock_get_credentials_file,
+    mock_is_registry_registered, mock_setup_registry,
+    mock_clean_registry_setup
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_credentials.return_value = 'foo', 'bar'
+    mock_is_registry_registered.return_value = False
+    mock_setup_registry.return_value = False
+    with raises(SystemExit) as sys_exit:
+        assert register_cloud_guest.setup_registry(smt_server)
+    assert sys_exit.value.code == 1
+
+
+@patch('cloudregister.registerutils.setup_registry')
+@patch('cloudregister.registerutils.is_registry_registered')
+@patch('cloudregister.registerutils.get_credentials_file')
+@patch('cloudregister.registerutils.get_credentials')
+def test_setup_registry_ok(
+    mock_get_credentials, mock_get_credentials_file,
+    mock_is_registry_registered, mock_setup_registry
+):
+    smt_data_ipv46 = dedent('''\
+        <smtInfo fingerprint="AA:BB:CC:DD"
+         SMTserverIP="1.2.3.5"
+         SMTserverIPv6="fc00::1"
+         SMTserverName="foo-ec2.susecloud.net"
+         SMTregistryName="registry-ec2.susecloud.net"
+         region="antarctica-1"/>''')
+    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    mock_get_credentials.return_value = 'foo', 'bar'
+    mock_is_registry_registered.return_value = False
+    mock_setup_registry.return_value = True
+    assert register_cloud_guest.setup_registry(smt_server) is None
+
+
+@patch('register_cloud_guest.logging')
+def test_get_responding_update_server_error(mock_logging):
+    with raises(SystemExit) as sys_exit:
+        assert register_cloud_guest.get_responding_update_server([])
+    assert sys_exit.value.code == 1
+    assert mock_logging.error.call_args_list == [call('No response from: []')]
+
+
+@patch('register_cloud_guest.os.path.isfile')
+def test_get_product_tree(mock_path_isfile):
+    base_product = dedent('''\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <product schemeversion="0">
+          <vendor>SUSE</vendor>
+          <name>SLES</name>
+          <version>15.4</version>
+          <baseversion>15</baseversion>
+          <patchlevel>4</patchlevel>
+          <release>0</release>
+          <endoflife></endoflife>
+          <arch>x86_64</arch></product>''')
+    expected_tree = etree.fromstring(
+        base_product[base_product.index('<product'):]
+    )
+    mock_path_isfile.return_value = True
+    with patch('builtins.open', mock_open(read_data=base_product)):
+        result = register_cloud_guest.get_product_tree()
+        assert etree.tostring(result) == etree.tostring(expected_tree)
+
+
+@patch('register_cloud_guest.logging')
+@patch('register_cloud_guest.get_product_tree')
+def test_setup_ltss_registration_no_product(
+    mock_get_product_tree, mock_logging
+):
+    mock_get_product_tree.return_value = None
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.setup_ltss_registration(
+            'target', 'regcode', 'instance_filepath'
+        )
+    assert sys_exit.value.code == 1
+    assert mock_logging.error.call_args_list == [
+        call('Cannot find baseproduct registration for LTSS')
+    ]
+
+
+@patch('register_cloud_guest.os.listdir')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.logging')
+@patch('register_cloud_guest.get_product_tree')
+def test_setup_ltss_registration_registered(
+    mock_get_product_tree, mock_logging, mock_os_path_isdir, mock_os_listdir
+):
+    mock_get_product_tree.return_value = True
+    mock_os_path_isdir.return_value = True
+    mock_os_listdir.return_value = ['LTSS']
+    assert register_cloud_guest.setup_ltss_registration(
+        'target', 'regcode', 'instance_filepath'
+    ) is None
+    assert mock_logging.info.call_args_list == [
+        call('Running LTSS registration...'),
+        call('LTSS registration succeeded')
+    ]
+
+
+@patch('register_cloud_guest.run_SUSEConnect')
+@patch('register_cloud_guest.os.listdir')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.logging')
+@patch('register_cloud_guest.get_product_tree')
+def test_setup_ltss_registration_registration_ok(
+    mock_get_product_tree, mock_logging,
+    mock_os_path_isdir, mock_os_listdir,
+    mock_run_SUSEConnect
+):
+    mock_os_path_isdir.return_value = True
+    mock_os_listdir.return_value = ['foo']
+    base_product = dedent('''\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <product schemeversion="0">
+          <vendor>SUSE</vendor>
+          <name>SLES</name>
+          <version>15.4</version>
+          <baseversion>15</baseversion>
+          <patchlevel>4</patchlevel>
+          <release>0</release>
+          <endoflife></endoflife>
+          <arch>x86_64</arch></product>''')
+    mock_get_product_tree.return_value = etree.fromstring(
+        base_product[base_product.index('<product'):]
+    )
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    mock_run_SUSEConnect.return_value = suseconnect_type(
+        returncode=0,
+        output='all OK',
+        error='stderr'
+    )
+    assert register_cloud_guest.setup_ltss_registration(
+        'target', 'regcode', 'instance_filepath'
+    ) is None
+    assert mock_logging.info.call_args_list == [
+        call('Running LTSS registration...'),
+        call('LTSS registration succeeded')
+    ]
+
+
+@patch('register_cloud_guest.run_SUSEConnect')
+@patch('register_cloud_guest.os.listdir')
+@patch('register_cloud_guest.os.path.isdir')
+@patch('register_cloud_guest.logging')
+@patch('register_cloud_guest.get_product_tree')
+def test_setup_ltss_registration_registration_failed(
+    mock_get_product_tree, mock_logging,
+    mock_os_path_isdir, mock_os_listdir,
+    mock_run_SUSEConnect
+):
+    mock_os_path_isdir.return_value = True
+    mock_os_listdir.return_value = ['foo']
+    base_product = dedent('''\
+        <?xml version="1.0" encoding="UTF-8"?>
+        <product schemeversion="0">
+          <vendor>SUSE</vendor>
+          <name>SLES</name>
+          <version>15.4</version>
+          <baseversion>15</baseversion>
+          <patchlevel>4</patchlevel>
+          <release>0</release>
+          <endoflife></endoflife>
+          <arch>x86_64</arch></product>''')
+    mock_get_product_tree.return_value = etree.fromstring(
+        base_product[base_product.index('<product'):]
+    )
+    suseconnect_type = namedtuple(
+        'suseconnect_type', ['returncode', 'output', 'error']
+    )
+    mock_run_SUSEConnect.return_value = suseconnect_type(
+        returncode=7,
+        output='not OK',
+        error='stderr'
+    )
+    with raises(SystemExit) as sys_exit:
+        register_cloud_guest.setup_ltss_registration(
+            'target', 'regcode', 'instance_filepath'
+        )
+    assert sys_exit.value.code == 1
+    assert mock_logging.error.call_args_list == [
+        call('LTSS registration failed'),
+        call('\tnot OK')
+    ]
+
+
+# Helper functions
+class Response():
+    """Fake a request response object"""
+    def json(self):
+        pass

--- a/tox.ini
+++ b/tox.ini
@@ -37,8 +37,10 @@ passenv =
 deps = {[testenv]deps}
 commands =
     python3 setup.py develop
-    py.test --no-cov-on-fail --cov=lib/cloudregister \
-        --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
+    py.test --no-cov-on-fail \
+    --cov=lib/cloudregister \
+    --cov=usr/sbin \
+    --cov-report=term-missing --cov-fail-under=100 --cov-config .coveragerc
 
 
 [testenv:unit_py3_11]

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -174,7 +174,10 @@ def run_SUSEConnect(
 
 
 # ----------------------------------------------------------------------------
-def register_modules(extensions, products, registered=[], failed=[]):
+def register_modules(
+    extensions, products, registration_target, instance_data_filepath,
+    registered=[], failed=[]
+):
     """Register modules obeying dependencies"""
     global registration_returncode
     for extension in extensions:
@@ -451,7 +454,9 @@ argparse.add_argument(
     )
 )
 
+
 def main(args):
+    global registration_returncode
     if args.user_smt_ip or args.user_smt_fqdn or args.user_smt_fp:
         if not (args.user_smt_ip and args.user_smt_fqdn and args.user_smt_fp):
             msg = '--smt-ip, --smt-fqdn, and --smt-fp must be used together'

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -482,7 +482,6 @@ def main(args):
             print(error_message, file=sys.stderr)
             sys.exit(1)
 
-
     if args.clean_up and args.force_new_registration:
         msg = '--clean and --force-new are incompatible, use one or the other'
         print(msg, file=sys.stderr)
@@ -668,9 +667,9 @@ def main(args):
                 registration_target_found = True
                 break
             else:
-                msg = 'Configured update server is unresponsive. Could not find '
-                msg += 'a replacement update server in this region. '
-                msg += 'Possible network configuration issue'
+                msg = 'Configured update server is unresponsive. '
+                msg += 'Could not find a replacement update server '
+                msg += 'in this region. Possible network configuration issue'
                 logging.error(msg)
                 sys.exit(1)
 
@@ -795,7 +794,9 @@ def main(args):
                         )
                     )
                     utils.remove_registration_data()
-                    utils.clean_hosts_file(registration_target.get_domain_name())
+                    utils.clean_hosts_file(
+                        registration_target.get_domain_name()
+                    )
                     registration_target = smt_srv
                     break
         else:
@@ -864,7 +865,8 @@ def main(args):
         for failed_extension in failed_extensions:
             print(activate_prod_cmd.format(failed_extension))
 
-    # Enable Nvidia repo if repo(s) are configured and destination can be reached
+    # Enable Nvidia repo if repo(s) are configured
+    # and destination can be reached
     if utils.has_nvidia_support():
         nvidia_repo_names = utils.find_repos('nvidia')
         for repo_name in nvidia_repo_names:

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -833,7 +833,7 @@ def main(args):
         logging.error(err_msg % (ips, res.reason, res.content.decode("UTF-8")))
         sys.exit(1)
 
-    prod_data = json.loads(res.text)
+    prod_data = res.json()
     extensions = prod_data.get('extensions')
     failed_extensions = []
     register_modules(extensions, products, failed=failed_extensions)

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -649,7 +649,7 @@ def main(args):
             for new_target in region_smt_servers:
                 if (
                         not new_target.is_responsive() or
-                        not registration_smt.is_equivalent()
+                        not registration_smt.is_equivalent(new_target)
                 ):
                     continue
                 smt_ip = new_target.get_ipv4()

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -878,8 +878,11 @@ def main(args):
             url = urllib.parse.urlparse(utils.get_repo_url(repo_name))
             cmd = ['ping', '-c', '2', url.hostname]
             if utils.exec_subprocess(cmd):
-                msg = 'Cannot reach host: "%s", will not enable repo "%s"'
-                logging.info(msg % (url.hostname, repo_name))
+                msg = (
+                    'Cannot reach host: "{hostname}", '
+                    'will not enable repo "{repo_name}"'
+                ).format(hostname=url.hostname, repo_name=repo_name)
+                logging.info(msg)
             else:
                 utils.enable_repository(repo_name)
 

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -450,426 +450,428 @@ argparse.add_argument(
     )
 )
 
-
-args = argparse.parse_args()
-
-if args.user_smt_ip or args.user_smt_fqdn or args.user_smt_fp:
-    if not (args.user_smt_ip and args.user_smt_fqdn and args.user_smt_fp):
-        msg = '--smt-ip, --smt-fqdn, and --smt-fp must be used together'
-        print(msg, file=sys.stderr)
-        sys.exit(1)
-
-    try:
-        ipaddress.ip_address(args.user_smt_ip)
-    except ValueError as err:
-        msg = "--smt-ip value '{ip_addr}' is not correct: {err}".format(
-            ip_addr=args.user_smt_ip,
-            err=err
-        )
-        print(msg, file=sys.stderr)
-        sys.exit(1)
-
-    if not utils.has_network_access_by_ip_address(args.user_smt_ip):
-        error_message = (
-            'Connection error: Could not establish a connection to {ip}.'
-            'Please, make sure the network configuration supports the '
-            'provided {ip} address version.'.format(ip=args.user_smt_ip)
-        )
-        print(error_message, file=sys.stderr)
-        sys.exit(1)
-
-
-if args.clean_up and args.force_new_registration:
-    msg = '--clean and --force-new are incompatible, use one or the other'
-    print(msg, file=sys.stderr)
-    sys.exit(1)
-
-    # Specifying reg code only works, but an e-mail requires a reg code
-if (args.email and not args.reg_code):
-    msg = '--email and --regcode must be used together'
-    print(msg, file=sys.stderr)
-    sys.exit(1)
-
-time.sleep(int(args.delay_time))
-
-config_file = args.config_file
-if config_file:
-    config_file = os.path.expanduser(args.config_file)
-cfg = utils.get_config(config_file)
-utils.start_logging()
-
-if args.clean_up:
-    logging.info('Registration clean up initiated by user')
-    cleanup()
-    sys.exit(0)
-
-if not os.path.isdir(utils.get_state_dir()):
-    os.makedirs(utils.get_state_dir())
-
-utils.set_new_registration_flag()
-if args.force_new_registration:
-    logging.info('Forced new registration')
-
-if args.user_smt_ip:
-    msg = 'Using user specified SMT server:\n'
-    msg += '\n\t"IP:%s"' % args.user_smt_ip
-    msg += '\n\t"FQDN:%s"' % args.user_smt_fqdn
-    msg += '\n\t"Fingerprint:%s"' % args.user_smt_fp
-    logging.info(msg)
-
-cached_smt_servers = utils.get_available_smt_servers()
-if cached_smt_servers:
-    # If we have an update server cache the system is registered in
-    # some way shape or form
-    utils.clear_new_registration_flag()
-else:
-    utils.write_framework_identifier(cfg)
-
-# Forced registration or user specified SMT, clear existing registration
-# data
-if (args.force_new_registration and cached_smt_servers) or args.user_smt_ip:
-    if utils.is_zypper_running():
-        msg = 'zypper is running: Registration with the update '
-        msg += 'infrastructure is only possible if zypper is not running.\n'
-        msg += 'Please re-run the force registration process after zypper '
-        msg += 'has completed'
-        print(msg)
-        sys.exit(1)
-    cleanup()
-    utils.set_new_registration_flag()
-    utils.write_framework_identifier(cfg)
-    cached_smt_servers = []
-
-# Proxy setup
-proxies = None
-proxy = utils.set_proxy()
-if proxy:
-    http_proxy = os.environ.get('http_proxy')
-    https_proxy = os.environ.get('https_proxy')
-    no_proxy = os.environ.get('no_proxy')
-    proxies = {'http_proxy': http_proxy,
-               'https_proxy': https_proxy,
-               'no_proxy': no_proxy}
-    logging.info('Using proxy settings: %s' % proxies)
-
-if args.user_smt_ip:
-    smt_xml = '<regionSMTdata><smtInfo '
-    smt_xml += 'fingerprint="%s" ' % args.user_smt_fp
-    smt_ip = ipaddress.ip_address(args.user_smt_ip)
-    if isinstance(smt_ip, ipaddress.IPv6Address):
-        smt_xml += 'SMTserverIPv6="%s" ' % args.user_smt_ip
-    elif isinstance(smt_ip, ipaddress.IPv4Address):
-        smt_xml += 'SMTserverIP="%s" ' % args.user_smt_ip
-    smt_xml += 'SMTserverName="%s" ' % args.user_smt_fqdn
-    registry_fqdn = 'registry-{}'.format(args.user_smt_fqdn.split('-')[1])
-    smt_xml += 'SMTregistryName="%s"' % registry_fqdn
-    smt_xml += '/></regionSMTdata>'
-    region_smt_data = etree.fromstring(smt_xml)
-else:
-    region_smt_data = utils.fetch_smt_data(cfg, proxies)
-
-registration_smt = utils.get_current_smt()
-
-# Check if we are in the same region
-region_smt_servers = cached_smt_servers
-region_change = utils.has_region_changed(cfg)
-if region_change and utils.uses_rmt_as_scc_proxy():
-    # We do not have the users registration code, stay connected to the
-    # servers in a different region.
-    # If the user also moved to a new framework registration will be broken
-    # due to the instance data.
-    # This code is a safe guard in case a user enabled the service on a BYOS
-    # instance, which is not supposed to be the case or tries
-    print('Region change detected:')
-    print(
-        '\tSystem uses SCC credentials, please re-register the system'
-        ' to the update infrastrusture in this region\n'
-        '\tregistercloudguest --clean\n'
-        '\tregistercloudguest -r YOUR_REG_CODE'
-    )
-elif region_change:
-    logging.info('Region change detected, registering to new servers')
-    cleanup()
-    region_smt_servers = cached_smt_servers = []
-    registration_smt = None
-    utils.set_new_registration_flag()
-    utils.write_framework_identifier(cfg)
-
-if not region_smt_servers:
-    cnt = 1
-    for child in region_smt_data:
-        smt_server = smt.SMT(child, utils.https_only(cfg))
-        region_smt_servers.append(smt_server)
-        # Write the available servers to cache as well
-        utils.store_smt_data(
-            os.path.join(
-                utils.get_state_dir(),
-                utils.AVAILABLE_SMT_SERVER_DATA_FILE_NAME % cnt
-            ),
-            smt_server
-        )
-        cnt += 1
-
-# Check if the target RMT for the registration is alive or if we can
-# find a server that is alive in this region
-registration_target_found = False
-if registration_smt:
-    registration_smt_cache_file_name = (
-        os.path.join(
-            utils.get_state_dir(),
-            utils.REGISTERED_SMT_SERVER_DATA_FILE_NAME
-        )
-    )
-    updated = utils.update_rmt_cert(registration_smt)
-    alive = registration_smt.is_responsive()
-    if alive:
-        msg = 'Instance is registered, and update server is reachable, '
-        msg += 'nothing to do'
-        # The cache data may have been cleared, write if necessary
-        if not os.path.exists(registration_smt_cache_file_name) or updated:
-            utils.store_smt_data(
-                registration_smt_cache_file_name,
-                registration_smt
-            )
-            if not utils.has_rmt_in_hosts(registration_smt):
-                utils.clean_hosts_file(registration_smt.get_domain_name())
-                utils.add_hosts_entry(registration_smt)
-        # The registry target may be missing, write if necessary
-        if not utils.has_registry_in_hosts(registration_smt):
-            utils.clean_hosts_file(registration_smt.get_domain_name())
-            utils.add_hosts_entry(registration_smt)
-        logging.info(msg)
-        registration_target_found = True
-    else:
-        # The current target server is not resposive, lets check if we can
-        # find another server
-        for new_target in region_smt_servers:
-            if (
-                    not new_target.is_responsive() or
-                    not registration_smt.is_equivalent()
-            ):
-                continue
-            smt_ip = new_target.get_ipv4()
-            if utils.has_rmt_ipv6_access(new_target):
-                smt_ip = new_target.get_ipv6()
-            msg = 'Configured update server is unresponsive, switching '
-            msg += 'to equivalent update server with ip %s' % smt_ip
-            utils.replace_hosts_entry(registration_smt, new_target)
-            utils.store_smt_data(
-                registration_smt_cache_file_name,
-                new_target
-            )
-            utils.update_rmt_cert(new_target)
-            registration_smt = new_target
-            registration_target_found = True
-            break
-        else:
-            msg = 'Configured update server is unresponsive. Could not find '
-            msg += 'a replacement update server in this region. '
-            msg += 'Possible network configuration issue'
-            logging.error(msg)
+def main(args):
+    if args.user_smt_ip or args.user_smt_fqdn or args.user_smt_fp:
+        if not (args.user_smt_ip and args.user_smt_fqdn and args.user_smt_fp):
+            msg = '--smt-ip, --smt-fqdn, and --smt-fp must be used together'
+            print(msg, file=sys.stderr)
             sys.exit(1)
 
-# Check if we need to send along any instance data
-instance_data_filepath = ''
-instance_data = utils.get_instance_data(cfg)
-if instance_data:
-    instance_data_filepath = os.path.join(
-        utils.get_state_dir(), str(uuid.uuid4())
-    )
-    inst_data_out = open(instance_data_filepath, 'w')
-    inst_data_out.write(instance_data)
-    inst_data_out.close()
+        try:
+            ipaddress.ip_address(args.user_smt_ip)
+        except ValueError as err:
+            msg = "--smt-ip value '{ip_addr}' is not correct: {err}".format(
+                ip_addr=args.user_smt_ip,
+                err=err
+            )
+            print(msg, file=sys.stderr)
+            sys.exit(1)
 
-if registration_target_found:
-    # The system is properly registered, run through the checklist now:
-    # 1. check/setup the container registry for this target
-    setup_registry(registration_smt)
-
-    # 2. check/setup if we got a regcode which is handled as LTSS
-    if args.reg_code:
-        setup_ltss_registration(
-            registration_smt,
-            args.reg_code,
-            instance_data_filepath
-        )
-
-    # All done, time to leave...
-    sys.exit(0)
-
-# We should not get here for a registered system that is a proxy. However,
-# it doesn't hurt to check and get out before breaking things
-if utils.uses_rmt_as_scc_proxy():
-    logging.info('System already uses the update infrastructure with a '
-                 'registration code, nothing to do')
-    sys.exit(0)
-
-# The system is not yet registered, Figure out which server
-# is responsive and use it as registration target
-registration_target = get_responding_update_server(region_smt_servers)
-
-# Create location to store data if it does not exist
-if not os.path.exists(utils.get_state_dir()):
-    os.system('mkdir -p %s' % utils.get_state_dir())
-
-# Write the data of the current target server
-utils.set_as_current_smt(registration_target)
-
-# Check if registration is supported
-if not utils.is_registration_supported(cfg):
-    sys.exit(0)
-
-register_cmd = get_register_cmd()
-if not (os.path.exists(register_cmd) and os.access(register_cmd, os.X_OK)):
-    err_msg = 'No registration executable found'
-    logging.error(err_msg)
-    print(err_msg, file=sys.stderr)
-    sys.exit(1)
-
-# get product list
-products = utils.get_installed_products()
-if products is None:
-    logging.error('No products installed on system')
-    sys.exit(1)
-
-if not utils.import_smt_cert(registration_target):
-    logging.error('SMT certificate import failed')
-    sys.exit(1)
-
-# Register the base product first
-base_registered = False
-failed_smts = []
-
-while not base_registered:
-    utils.add_hosts_entry(registration_target)
-    suseconnect = run_SUSEConnect(
-        registration_target=registration_target,
-        email=args.email,
-        regcode=args.reg_code,
-        instance_data_filepath=instance_data_filepath
-    )
-    if suseconnect.returncode:
-        registration_returncode = suseconnect.returncode
-        # Even on error SUSEConnect writes messages to stdout, go figure
-        error_message = suseconnect.output
-        failed_smts.append(registration_target.get_ipv4())
-        if (
-            len(failed_smts) == len(region_smt_servers) or
-            (registration_returncode == 67 and
-             'registration code' in error_message.lower() and
-             args.reg_code)
-        ):
-            # there are no more RMT servers to try to register to or
-            # registration failed because of an invalid reg code
-            # and that SCC response will not change, independently
-            # of the RMT sibling selected
-            # SCC exit codes:
-            # 0: Registration successful
-            # 64: Connection refused
-            # 65: Access error, e.g. files not readable
-            # 66: Parser error: Server JSON response was not parseable
-            # 67: Server responded with error: see log output
-            logging.error('Baseproduct registration failed')
-            logging.error('\t%s' % error_message)
-            cleanup()
+        if not utils.has_network_access_by_ip_address(args.user_smt_ip):
+            error_message = (
+                'Connection error: Could not establish a connection to {ip}.'
+                'Please, make sure the network configuration supports the '
+                'provided {ip} address version.'.format(ip=args.user_smt_ip)
+            )
             print(error_message, file=sys.stderr)
             sys.exit(1)
-        for smt_srv in region_smt_servers:
-            target_smt_ipv4 = registration_target.get_ipv4()
-            target_smt_ipv6 = registration_target.get_ipv6()
-            new_smt_ipv4 = smt_srv.get_ipv4()
-            new_smt_ipv6 = smt_srv.get_ipv6()
-            if (
-                    smt_srv.get_ipv4() != registration_target.get_ipv4() and
-                    smt_srv.get_ipv4() not in failed_smts
-            ):
-                error_msg = 'Registration with %s failed. Trying %s'
-                logging.error(
-                    error_msg % (
-                        str((target_smt_ipv4, target_smt_ipv6)),
-                        str((new_smt_ipv4, new_smt_ipv6))
-                    )
-                )
-                utils.remove_registration_data()
-                utils.clean_hosts_file(registration_target.get_domain_name())
-                registration_target = smt_srv
-                break
-    else:
-        logging.info('Baseproduct registration complete')
-        base_registered = True
+
+
+    if args.clean_up and args.force_new_registration:
+        msg = '--clean and --force-new are incompatible, use one or the other'
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+
+        # Specifying reg code only works, but an e-mail requires a reg code
+    if (args.email and not args.reg_code):
+        msg = '--email and --regcode must be used together'
+        print(msg, file=sys.stderr)
+        sys.exit(1)
+
+    time.sleep(int(args.delay_time))
+
+    config_file = args.config_file
+    if config_file:
+        config_file = os.path.expanduser(args.config_file)
+    cfg = utils.get_config(config_file)
+    utils.start_logging()
+
+    if args.clean_up:
+        logging.info('Registration clean up initiated by user')
+        cleanup()
+        sys.exit(0)
+
+    if not os.path.isdir(utils.get_state_dir()):
+        os.makedirs(utils.get_state_dir())
+
+    utils.set_new_registration_flag()
+    if args.force_new_registration:
+        logging.info('Forced new registration')
+
+    if args.user_smt_ip:
+        msg = 'Using user specified SMT server:\n'
+        msg += '\n\t"IP:%s"' % args.user_smt_ip
+        msg += '\n\t"FQDN:%s"' % args.user_smt_fqdn
+        msg += '\n\t"Fingerprint:%s"' % args.user_smt_fp
+        logging.info(msg)
+
+    cached_smt_servers = utils.get_available_smt_servers()
+    if cached_smt_servers:
+        # If we have an update server cache the system is registered in
+        # some way shape or form
         utils.clear_new_registration_flag()
-        if args.email or args.reg_code:
-            utils.set_rmt_as_scc_proxy_flag()
+    else:
+        utils.write_framework_identifier(cfg)
 
-base_product = get_product_triplet(
-    get_product_tree()
-)
-headers = {'Accept': 'application/vnd.scc.suse.com.v4+json'}
-query_args = 'identifier=%s&version=%s&arch=%s' % (
-    base_product.name, base_product.version, base_product.arch
-)
-user, password = utils.get_credentials(
-    utils.get_credentials_file(registration_target)
-)
-auth_creds = HTTPBasicAuth(user, password)
-res = requests.get(
-    'https://%s/connect/systems/products?%s' % (
-        registration_target.get_FQDN(), query_args
-    ),
-    auth=auth_creds,
-    headers=headers
-)
-if res.status_code != 200:
-    err_msg = 'Unable to obtain product information from server "%s"\n'
-    err_msg += '\t%s\n\t%s\nUnable to register modules, exiting.'
-    ips = '%s,%s' % (
-        registration_target.get_ipv4(), registration_target.get_ipv6()
-    )
-    logging.error(err_msg % (ips, res.reason, res.content.decode("UTF-8")))
-    sys.exit(1)
+    # Forced registration or user specified SMT, clear existing registration
+    # data
+    if (args.force_new_registration and cached_smt_servers) or args.user_smt_ip:
+        if utils.is_zypper_running():
+            msg = 'zypper is running: Registration with the update '
+            msg += 'infrastructure is only possible if zypper is not running.\n'
+            msg += 'Please re-run the force registration process after zypper '
+            msg += 'has completed'
+            print(msg)
+            sys.exit(1)
+        cleanup()
+        utils.set_new_registration_flag()
+        utils.write_framework_identifier(cfg)
+        cached_smt_servers = []
 
-prod_data = json.loads(res.text)
-extensions = prod_data.get('extensions')
-failed_extensions = []
-register_modules(extensions, products, failed=failed_extensions)
+    # Proxy setup
+    proxies = None
+    proxy = utils.set_proxy()
+    if proxy:
+        http_proxy = os.environ.get('http_proxy')
+        https_proxy = os.environ.get('https_proxy')
+        no_proxy = os.environ.get('no_proxy')
+        proxies = {'http_proxy': http_proxy,
+                   'https_proxy': https_proxy,
+                   'no_proxy': no_proxy}
+        logging.info('Using proxy settings: %s' % proxies)
 
-if os.path.exists(instance_data_filepath):
-    os.unlink(instance_data_filepath)
+    if args.user_smt_ip:
+        smt_xml = '<regionSMTdata><smtInfo '
+        smt_xml += 'fingerprint="%s" ' % args.user_smt_fp
+        smt_ip = ipaddress.ip_address(args.user_smt_ip)
+        if isinstance(smt_ip, ipaddress.IPv6Address):
+            smt_xml += 'SMTserverIPv6="%s" ' % args.user_smt_ip
+        elif isinstance(smt_ip, ipaddress.IPv4Address):
+            smt_xml += 'SMTserverIP="%s" ' % args.user_smt_ip
+        smt_xml += 'SMTserverName="%s" ' % args.user_smt_fqdn
+        registry_fqdn = 'registry-{}'.format(args.user_smt_fqdn.split('-')[1])
+        smt_xml += 'SMTregistryName="%s"' % registry_fqdn
+        smt_xml += '/></regionSMTdata>'
+        region_smt_data = etree.fromstring(smt_xml)
+    else:
+        region_smt_data = utils.fetch_smt_data(cfg, proxies)
 
-if registration_returncode:
-    cleanup()
-    print(
-        'Registration failed(repository), see {0} for details'.format(
-            LOG_FILE
-        ), file=sys.stderr
-    )
-    sys.exit(registration_returncode)
+    registration_smt = utils.get_current_smt()
 
-# Setup container registry
-setup_registry(registration_target)
+    # Check if we are in the same region
+    region_smt_servers = cached_smt_servers
+    region_change = utils.has_region_changed(cfg)
+    if region_change and utils.uses_rmt_as_scc_proxy():
+        # We do not have the users registration code, stay connected to the
+        # servers in a different region.
+        # If the user also moved to a new framework registration will be broken
+        # due to the instance data.
+        # This code is a safe guard in case a user enabled the service on a BYOS
+        # instance, which is not supposed to be the case or tries
+        print('Region change detected:')
+        print(
+            '\tSystem uses SCC credentials, please re-register the system'
+            ' to the update infrastrusture in this region\n'
+            '\tregistercloudguest --clean\n'
+            '\tregistercloudguest -r YOUR_REG_CODE'
+        )
+    elif region_change:
+        logging.info('Region change detected, registering to new servers')
+        cleanup()
+        region_smt_servers = cached_smt_servers = []
+        registration_smt = None
+        utils.set_new_registration_flag()
+        utils.write_framework_identifier(cfg)
 
-print('Registration succeeded')
+    if not region_smt_servers:
+        cnt = 1
+        for child in region_smt_data:
+            smt_server = smt.SMT(child, utils.https_only(cfg))
+            region_smt_servers.append(smt_server)
+            # Write the available servers to cache as well
+            utils.store_smt_data(
+                os.path.join(
+                    utils.get_state_dir(),
+                    utils.AVAILABLE_SMT_SERVER_DATA_FILE_NAME % cnt
+                ),
+                smt_server
+            )
+            cnt += 1
 
-if failed_extensions:
-    print(
-        'There are products that were not registered because they need '
-        'an additional registration code, to register them please run '
-        'the following command:'
-    )
-    activate_prod_cmd = 'SUSEConnect -p {} -r ADDITIONAL REGCODE'
-    for failed_extension in failed_extensions:
-        print(activate_prod_cmd.format(failed_extension))
-
-# Enable Nvidia repo if repo(s) are configured and destination can be reached
-if utils.has_nvidia_support():
-    nvidia_repo_names = utils.find_repos('nvidia')
-    for repo_name in nvidia_repo_names:
-        url = urllib.parse.urlparse(utils.get_repo_url(repo_name))
-        cmd = ['ping', '-c', '2', url.hostname]
-        if utils.exec_subprocess(cmd):
-            msg = 'Cannot reach host: "%s", will not enable repo "%s"'
-            logging.info(msg % (url.hostname, repo_name))
+    # Check if the target RMT for the registration is alive or if we can
+    # find a server that is alive in this region
+    registration_target_found = False
+    if registration_smt:
+        registration_smt_cache_file_name = (
+            os.path.join(
+                utils.get_state_dir(),
+                utils.REGISTERED_SMT_SERVER_DATA_FILE_NAME
+            )
+        )
+        updated = utils.update_rmt_cert(registration_smt)
+        alive = registration_smt.is_responsive()
+        if alive:
+            msg = 'Instance is registered, and update server is reachable, '
+            msg += 'nothing to do'
+            # The cache data may have been cleared, write if necessary
+            if not os.path.exists(registration_smt_cache_file_name) or updated:
+                utils.store_smt_data(
+                    registration_smt_cache_file_name,
+                    registration_smt
+                )
+                if not utils.has_rmt_in_hosts(registration_smt):
+                    utils.clean_hosts_file(registration_smt.get_domain_name())
+                    utils.add_hosts_entry(registration_smt)
+            # The registry target may be missing, write if necessary
+            if not utils.has_registry_in_hosts(registration_smt):
+                utils.clean_hosts_file(registration_smt.get_domain_name())
+                utils.add_hosts_entry(registration_smt)
+            logging.info(msg)
+            registration_target_found = True
         else:
-            utils.enable_repository(repo_name)
+            # The current target server is not resposive, lets check if we can
+            # find another server
+            for new_target in region_smt_servers:
+                if (
+                        not new_target.is_responsive() or
+                        not registration_smt.is_equivalent()
+                ):
+                    continue
+                smt_ip = new_target.get_ipv4()
+                if utils.has_rmt_ipv6_access(new_target):
+                    smt_ip = new_target.get_ipv6()
+                msg = 'Configured update server is unresponsive, switching '
+                msg += 'to equivalent update server with ip %s' % smt_ip
+                utils.replace_hosts_entry(registration_smt, new_target)
+                utils.store_smt_data(
+                    registration_smt_cache_file_name,
+                    new_target
+                )
+                utils.update_rmt_cert(new_target)
+                registration_smt = new_target
+                registration_target_found = True
+                break
+            else:
+                msg = 'Configured update server is unresponsive. Could not find '
+                msg += 'a replacement update server in this region. '
+                msg += 'Possible network configuration issue'
+                logging.error(msg)
+                sys.exit(1)
 
-utils.switch_services_to_plugin()
+    # Check if we need to send along any instance data
+    instance_data_filepath = ''
+    instance_data = utils.get_instance_data(cfg)
+    if instance_data:
+        instance_data_filepath = os.path.join(
+            utils.get_state_dir(), str(uuid.uuid4())
+        )
+        inst_data_out = open(instance_data_filepath, 'w')
+        inst_data_out.write(instance_data)
+        inst_data_out.close()
+
+    if registration_target_found:
+        # The system is properly registered, run through the checklist now:
+        # 1. check/setup the container registry for this target
+        setup_registry(registration_smt)
+
+        # 2. check/setup if we got a regcode which is handled as LTSS
+        if args.reg_code:
+            setup_ltss_registration(
+                registration_smt,
+                args.reg_code,
+                instance_data_filepath
+            )
+
+        # All done, time to leave...
+        sys.exit(0)
+
+    # We should not get here for a registered system that is a proxy. However,
+    # it doesn't hurt to check and get out before breaking things
+    if utils.uses_rmt_as_scc_proxy():
+        logging.info('System already uses the update infrastructure with a '
+                     'registration code, nothing to do')
+        sys.exit(0)
+
+    # The system is not yet registered, Figure out which server
+    # is responsive and use it as registration target
+    registration_target = get_responding_update_server(region_smt_servers)
+
+    # Create location to store data if it does not exist
+    if not os.path.exists(utils.get_state_dir()):
+        os.system('mkdir -p %s' % utils.get_state_dir())
+
+    # Write the data of the current target server
+    utils.set_as_current_smt(registration_target)
+
+    # Check if registration is supported
+    if not utils.is_registration_supported(cfg):
+        sys.exit(0)
+
+    register_cmd = get_register_cmd()
+    if not (os.path.exists(register_cmd) and os.access(register_cmd, os.X_OK)):
+        err_msg = 'No registration executable found'
+        logging.error(err_msg)
+        print(err_msg, file=sys.stderr)
+        sys.exit(1)
+
+    # get product list
+    products = utils.get_installed_products()
+    if products is None:
+        logging.error('No products installed on system')
+        sys.exit(1)
+
+    if not utils.import_smt_cert(registration_target):
+        logging.error('SMT certificate import failed')
+        sys.exit(1)
+
+    # Register the base product first
+    base_registered = False
+    failed_smts = []
+
+    while not base_registered:
+        utils.add_hosts_entry(registration_target)
+        suseconnect = run_SUSEConnect(
+            registration_target=registration_target,
+            email=args.email,
+            regcode=args.reg_code,
+            instance_data_filepath=instance_data_filepath
+        )
+        if suseconnect.returncode:
+            registration_returncode = suseconnect.returncode
+            # Even on error SUSEConnect writes messages to stdout, go figure
+            error_message = suseconnect.output
+            failed_smts.append(registration_target.get_ipv4())
+            if (
+                len(failed_smts) == len(region_smt_servers) or
+                (registration_returncode == 67 and
+                 'registration code' in error_message.lower() and
+                 args.reg_code)
+            ):
+                # there are no more RMT servers to try to register to or
+                # registration failed because of an invalid reg code
+                # and that SCC response will not change, independently
+                # of the RMT sibling selected
+                # SCC exit codes:
+                # 0: Registration successful
+                # 64: Connection refused
+                # 65: Access error, e.g. files not readable
+                # 66: Parser error: Server JSON response was not parseable
+                # 67: Server responded with error: see log output
+                logging.error('Baseproduct registration failed')
+                logging.error('\t%s' % error_message)
+                cleanup()
+                print(error_message, file=sys.stderr)
+                sys.exit(1)
+            for smt_srv in region_smt_servers:
+                target_smt_ipv4 = registration_target.get_ipv4()
+                target_smt_ipv6 = registration_target.get_ipv6()
+                new_smt_ipv4 = smt_srv.get_ipv4()
+                new_smt_ipv6 = smt_srv.get_ipv6()
+                if (
+                        smt_srv.get_ipv4() != registration_target.get_ipv4() and
+                        smt_srv.get_ipv4() not in failed_smts
+                ):
+                    error_msg = 'Registration with %s failed. Trying %s'
+                    logging.error(
+                        error_msg % (
+                            str((target_smt_ipv4, target_smt_ipv6)),
+                            str((new_smt_ipv4, new_smt_ipv6))
+                        )
+                    )
+                    utils.remove_registration_data()
+                    utils.clean_hosts_file(registration_target.get_domain_name())
+                    registration_target = smt_srv
+                    break
+        else:
+            logging.info('Baseproduct registration complete')
+            base_registered = True
+            utils.clear_new_registration_flag()
+            if args.email or args.reg_code:
+                utils.set_rmt_as_scc_proxy_flag()
+
+    base_product = get_product_triplet(
+        get_product_tree()
+    )
+    headers = {'Accept': 'application/vnd.scc.suse.com.v4+json'}
+    query_args = 'identifier=%s&version=%s&arch=%s' % (
+        base_product.name, base_product.version, base_product.arch
+    )
+    user, password = utils.get_credentials(
+        utils.get_credentials_file(registration_target)
+    )
+    auth_creds = HTTPBasicAuth(user, password)
+    res = requests.get(
+        'https://%s/connect/systems/products?%s' % (
+            registration_target.get_FQDN(), query_args
+        ),
+        auth=auth_creds,
+        headers=headers
+    )
+    if res.status_code != 200:
+        err_msg = 'Unable to obtain product information from server "%s"\n'
+        err_msg += '\t%s\n\t%s\nUnable to register modules, exiting.'
+        ips = '%s,%s' % (
+            registration_target.get_ipv4(), registration_target.get_ipv6()
+        )
+        logging.error(err_msg % (ips, res.reason, res.content.decode("UTF-8")))
+        sys.exit(1)
+
+    prod_data = json.loads(res.text)
+    extensions = prod_data.get('extensions')
+    failed_extensions = []
+    register_modules(extensions, products, failed=failed_extensions)
+
+    if os.path.exists(instance_data_filepath):
+        os.unlink(instance_data_filepath)
+
+    if registration_returncode:
+        cleanup()
+        print(
+            'Registration failed(repository), see {0} for details'.format(
+                LOG_FILE
+            ), file=sys.stderr
+        )
+        sys.exit(registration_returncode)
+
+    # Setup container registry
+    setup_registry(registration_target)
+
+    print('Registration succeeded')
+
+    if failed_extensions:
+        print(
+            'There are products that were not registered because they need '
+            'an additional registration code, to register them please run '
+            'the following command:'
+        )
+        activate_prod_cmd = 'SUSEConnect -p {} -r ADDITIONAL REGCODE'
+        for failed_extension in failed_extensions:
+            print(activate_prod_cmd.format(failed_extension))
+
+    # Enable Nvidia repo if repo(s) are configured and destination can be reached
+    if utils.has_nvidia_support():
+        nvidia_repo_names = utils.find_repos('nvidia')
+        for repo_name in nvidia_repo_names:
+            url = urllib.parse.urlparse(utils.get_repo_url(repo_name))
+            cmd = ['ping', '-c', '2', url.hostname]
+            if utils.exec_subprocess(cmd):
+                msg = 'Cannot reach host: "%s", will not enable repo "%s"'
+                logging.info(msg % (url.hostname, repo_name))
+            else:
+                utils.enable_repository(repo_name)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    args = argparse.parse_args()
+    main(args)
+    utils.switch_services_to_plugin()

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -134,9 +134,9 @@ def run_SUSEConnect(
 
     # distinguish command between standard and read-only system(transactional)
     if 'transactional' in register_cmd:
-        cmd += ['register', '--url', 'https://{0}'.format(target_url)]
-    else:
-        cmd += ['--url', 'https://{0}'.format(target_url)]
+        cmd += ['register']
+
+    cmd += ['--url', 'https://{0}'.format(target_url)]
 
     # SUSE product triplet
     if product:

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -836,8 +836,13 @@ def main(args):
     prod_data = res.json()
     extensions = prod_data.get('extensions')
     failed_extensions = []
-    register_modules(extensions, products, failed=failed_extensions)
-
+    register_modules(
+        extensions,
+        products,
+        registration_target,
+        instance_data_filepath,
+        failed=failed_extensions
+    )
     if os.path.exists(instance_data_filepath):
         os.unlink(instance_data_filepath)
 

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -124,7 +124,8 @@ def run_SUSEConnect(
     )
     register_cmd = get_register_cmd()
     if not (os.path.exists(register_cmd) and os.access(register_cmd, os.X_OK)):
-        logging.error('No registration executable found')
+        err_msg = 'No registration executable found'
+        logging.error(err_msg)
         print(err_msg, file=sys.stderr)
         sys.exit(1)
 


### PR DESCRIPTION
It happens (and it has happened) that some errors/bugs come from registercloudguest due to
either missing things or having things not correctly set which would get caught if registercloudguest had tests

Some corrections were done (each of them has its own commit) even in this PR as they were found during the tests addition

This PR aims to reduce the amount of missing things in this project

- Modify registercloudguest to call main()
- Add tests to registercloudguest
- Add a check to keep the coverage for registercloudguest at 100%
- Add linter check for registercloudguest