### PR TITLE
Keep free registry url

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -910,7 +910,6 @@ def clean_registries_conf_podman(private_registry_fqdn):
     unqualified_search_reg = registries_conf.get(
         'unqualified-search-registries', []
     )
-    pub_registry_fqdn = 'registry.suse.com'
     if unqualified_search_reg:
         if private_registry_fqdn:
             if private_registry_fqdn in unqualified_search_reg:
@@ -928,12 +927,6 @@ def clean_registries_conf_podman(private_registry_fqdn):
 
             if modified:
                 unqualified_search_reg = new_unq_search_reg
-
-        if pub_registry_fqdn in unqualified_search_reg:
-            unqualified_search_reg.pop(
-                unqualified_search_reg.index(pub_registry_fqdn)
-            )
-            modified = True
 
         if modified:
             registries_conf['unqualified-search-registries'] = \

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -4182,7 +4182,9 @@ def test_clean_registries_conf_podman_file_clean_content_smt_OK(
         ]
         mock_toml_dump.assert_called_once_with(
             {
-                'unqualified-search-registries': ['foo.com'],
+                'unqualified-search-registries': [
+                    'foo.com', 'registry.suse.com'
+                ],
                 'registry': [{'location': 'foo', 'insecure': False}]
             },
             file_handle
@@ -4201,7 +4203,7 @@ def test_clean_registries_conf_podman_file_clean_content_smt_OK_empty(
     registry_fqdn = 'registry-foo.susecloud.net'
     mock_toml_load.return_value = {
         'unqualified-search-registries': [
-            'registry.suse.com', 'registry-foo.susecloud.net'
+            'registry-foo.susecloud.net'
         ],
         'registry': [
             {'location': registry_fqdn, 'insecure': False}
@@ -4261,7 +4263,9 @@ def test_clean_registries_conf_podman_file_clean_content_no_smt(
         ]
         mock_toml_dump.assert_called_once_with(
             {
-                'unqualified-search-registries': ['foo.com'],
+                'unqualified-search-registries': [
+                    'foo.com', 'registry.suse.com'
+                ],
                 'registry': [{'location': 'foo', 'insecure': False}]
             },
             file_handle


### PR DESCRIPTION
When cleaning up the registry info, we remove bith the private and the public registry url, we should keep the public url

Otherwise, a command like

podman search bci

would not produce any results when it should show at least any match on registry.suse.com