### PR TITLE
Fix setup of unqualified search registries

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -54,6 +54,7 @@ REGISTRIES_CONF_PATH = '/etc/containers/registries.conf'
 DOCKER_CONFIG_PATH = '/etc/docker/daemon.json'
 SUMA_REGISTRY_CONF_PATH = '/etc/uyuni/uyuni-tools.yaml'
 BASE_PRODUCT_PATH = '/etc/products.d/baseproduct'
+SUSE_REGISTRY = 'registry.suse.com'
 
 requests.packages.urllib3.disable_warnings(
     requests.packages.urllib3.exceptions.InsecureRequestWarning
@@ -1238,9 +1239,9 @@ def clean_registries_conf_docker(private_registry_fqdn):
             )
             modified = True
 
-        if 'https://registry.suse.com' in registry_mirrors:
+        if 'https://{0}'.format(SUSE_REGISTRY) in registry_mirrors:
             registry_mirrors.pop(
-                registry_mirrors.index('https://registry.suse.com')
+                registry_mirrors.index('https://{0}'.format(SUSE_REGISTRY))
             )
             modified = True
     else:
@@ -1248,7 +1249,7 @@ def clean_registries_conf_docker(private_registry_fqdn):
         for registry in registry_mirrors:
             if (
                 ('registry' in registry and 'susecloud.net' in registry) or
-                'registry.suse.com' in registry
+                SUSE_REGISTRY in registry
             ):
                 modified = True
                 continue
@@ -2635,8 +2636,6 @@ def __set_registries_conf_podman(private_registry_fqdn):
         if failed:
             return False
 
-    public_registry_fqdn = 'registry.suse.com'
-    unqualified_search_reg = []
     unqualified_search_reg = registries_conf.get(
         'unqualified-search-registries', []
     )
@@ -2646,8 +2645,8 @@ def __set_registries_conf_podman(private_registry_fqdn):
         pub_index = -1
         if private_registry_fqdn in unqualified_search_reg:
             priv_index = unqualified_search_reg.index(private_registry_fqdn)
-        if public_registry_fqdn in unqualified_search_reg:
-            pub_index = unqualified_search_reg.index(public_registry_fqdn)
+        if SUSE_REGISTRY in unqualified_search_reg:
+            pub_index = unqualified_search_reg.index(SUSE_REGISTRY)
 
         if not priv_index == 0 or not pub_index == 1:
             if priv_index > 0:
@@ -2659,7 +2658,7 @@ def __set_registries_conf_podman(private_registry_fqdn):
     if modified or not unqualified_search_reg:
         [
             unqualified_search_reg.insert(0, fqdn) for fqdn in
-            [public_registry_fqdn, private_registry_fqdn]
+            [SUSE_REGISTRY, private_registry_fqdn]
         ]
 
     private_registry = {'location': private_registry_fqdn, 'insecure': False}
@@ -2699,8 +2698,8 @@ def __set_registries_conf_podman(private_registry_fqdn):
 # ----------------------------------------------------------------------------
 def __set_registries_conf_docker(private_registry_fqdn):
     # search is disabled for Docker server side for private registry
-    public_registry_url = 'https://registry.suse.com'
-    private_registry_url = 'https://' + private_registry_fqdn
+    public_registry_url = 'https://{0}'.format(SUSE_REGISTRY)
+    private_registry_url = 'https://{0}'.format(private_registry_fqdn)
     docker_cfg_json = {}
     registry_mirrors = []
     os.makedirs(os.path.dirname(DOCKER_CONFIG_PATH), exist_ok=True)

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -1143,7 +1143,6 @@ def clean_registries_conf_podman(private_registry_fqdn):
     if private_registry_fqdn in unqualified_search_reg:
         unqualified_search_reg.remove(private_registry_fqdn)
         modified_by_us = True
-    registries_conf['unqualified-search-registries'] = unqualified_search_reg
 
     # Drop from registry
     registry_mirrors = registries_conf.get(
@@ -1156,10 +1155,12 @@ def clean_registries_conf_podman(private_registry_fqdn):
             modified_by_us = True
             break
         mirror_index += 1
-    registries_conf['registry'] = registry_mirrors
 
     # write registry setup if modified by us
     if modified_by_us:
+        registries_conf['unqualified-search-registries'] = \
+            unqualified_search_reg
+        registries_conf['registry'] = registry_mirrors
         logging.info(
             'SUSE registry information has been removed from {0}'.format(
                 REGISTRIES_CONF_PATH
@@ -1198,10 +1199,10 @@ def clean_registries_conf_docker(private_registry_fqdn):
     if private_registry_url in registry_mirrors:
         registry_mirrors.remove(private_registry_url)
         modified_by_us = True
-    docker_cfg_json['registry-mirrors'] = registry_mirrors
 
     # write registry setup if modified by us
     if modified_by_us:
+        docker_cfg_json['registry-mirrors'] = registry_mirrors
         logging.info(
             'SUSE registry information has been removed from {0}'.format(
                 DOCKER_CONFIG_PATH
@@ -2594,7 +2595,6 @@ def __set_registries_conf_podman(private_registry_fqdn):
         )
         unqualified_search_reg.insert(private_registry_index + 1, SUSE_REGISTRY)
         modified_by_us = True
-    registries_conf['unqualified-search-registries'] = unqualified_search_reg
 
     # Setup registry mirror
     registry_mirrors = registries_conf.get(
@@ -2610,10 +2610,12 @@ def __set_registries_conf_podman(private_registry_fqdn):
             {'location': private_registry_fqdn, 'insecure': False}
         )
         modified_by_us = True
-    registries_conf['registry'] = registry_mirrors
 
     # write registry setup if modified by us
     if modified_by_us:
+        registries_conf['unqualified-search-registries'] = \
+            unqualified_search_reg
+        registries_conf['registry'] = registry_mirrors
         logging.info(
             'Content for {0} has changed, updating the file'.format(
                 REGISTRIES_CONF_PATH
@@ -2659,10 +2661,10 @@ def __set_registries_conf_docker(private_registry_fqdn):
             private_registry_index + 1, suse_registry_url
         )
         modified_by_us = True
-    docker_cfg_json['registry-mirrors'] = registry_mirrors
 
     # write registry setup if modified by us
     if modified_by_us:
+        docker_cfg_json['registry-mirrors'] = registry_mirrors
         return write_registries_conf(
             docker_cfg_json, DOCKER_CONFIG_PATH, 'docker'
         )

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -5114,7 +5114,7 @@ def test_set_registries_conf_docker_no_matches(
 # ---------------------------------------------------------------------------
 @patch('cloudregister.registerutils.get_registry_conf_file')
 @patch('cloudregister.registerutils.json.dump')
-def test_set_registries_conf_docker_unordered_matches(
+def test_set_registries_conf_docker_not_OK_order_has_changed(
     mock_json_dump, mock_get_registry_conf_file
 ):
     with patch('builtins.open', create=True) as mock_open:
@@ -5124,8 +5124,6 @@ def test_set_registries_conf_docker_unordered_matches(
             return mock_open_podman_config.return_value
 
         mock_open.side_effect = open_file
-        file_handle = \
-            mock_open_podman_config.return_value.__enter__.return_value
         mock_get_registry_conf_file.return_value = {
             'registry-mirrors': [
                 'foo',
@@ -5135,17 +5133,10 @@ def test_set_registries_conf_docker_unordered_matches(
             'bar': ['bar'],
         }, False
         utils.__set_registries_conf_docker('registry-foo.susecloud.net')
-        mock_json_dump.assert_called_once_with(
-            {
-                'registry-mirrors': [
-                    'https://registry-foo.susecloud.net',
-                    'https://registry.suse.com',
-                    'foo'
-                ],
-                'bar': ['bar']
-            },
-            file_handle
-        )
+        # The registry setup contains the entries we care but was
+        # modified manually. Don't touch this user modified variant.
+        # This can be changed by the user via a --clean re-registration
+        assert not mock_json_dump.called
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This patch is many fold and the result of testing our registry setup and cleanup. I found the following defects while testing:

1. There is an index comparison issue at setup of the podman and docker registry files, which leads to duplicate entries if the first element is registry.suse.com
2. The cleanup method deletes files that belongs to the `libcontainers-common` package and that deletion drops more information than just the registry search path which will then never be restored.
3. If a user creates manual changes on the registry search path that are **not** related to our private registry path (which must  be first) we still change the order of entries in our registration process. This is an unexpected and also unwanted behavior
4. Overall the implementation for setup and cleanup could be simpler and easier to read, that's why I also refactored the code to fix all issues found.
5. Static information like registry.suse.com was spread across the code when it should exist only once

This PR has been integration tested with the above issues in mind. 

The commit list separates the changes into three areas
* de-duplication
* changes for the setup methods
* changes for the cleanup methods

I suggest to review commit based

Thanks