### PR TITLE
Use the region endpoint of IMDS in EC2

### DIFF
--- a/cloud-regionsrv-client.changes
+++ b/cloud-regionsrv-client.changes
@@ -1,15 +1,20 @@
 -------------------------------------------------------------------
-Thu Oct  3 10:31:39 UTC 2024 - Marcus Schäfer <marcus.schaefer@suse.com>
+Upcoming 10.3.6
 
-- Deregister non free extensions at registercloudguest --clean
-- Fix registry cleanup at registercloudguest --clean, don't remove files
-- Prevent duplicate search entries in registry setup
+- Update to 10.3.6 (jsc#PCT-471)
+  + Deregister non free extensions at registercloudguest --clean
+  + Fix registry cleanup at registercloudguest --clean, don't remove files
+  + Prevent duplicate search entries in registry setup
+- Update EC2 plugin to 1.0.5
+  + Switch to using the region endpoint from IMDS to determine the region
+    instead of deriving the data from the availability zone
 
 -------------------------------------------------------------------
 Wed Sep 11 13:20:32 UTC 2024 - Robert Schweikert <rjschwei@suse.com>
 
-- Update spec file to build in all code streams,
-  SLE 12, SLE 15, ALP, and SLFO and have proper dependencies
+- Update to 10.3.5
+  + Update spec file to build in all code streams,
+    SLE 12, SLE 15, ALP, and SLFO and have proper dependencies
 
 -------------------------------------------------------------------
 Wed Aug 28 20:17:24 UTC 2024 - Robert Schweikert <rjschwei@suse.com>

--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -113,7 +113,7 @@ Requires:       cloud-regionsrv-client >= 6.0.0
 Guest registration plugin for images intended for Google Compute Engine
 
 %package plugin-ec2
-Version:        1.0.4
+Version:        1.0.5
 Release:        0
 Summary:        Cloud Environment Guest Registration Plugin for Amazon EC2
 Group:          Productivity/Networking/Web/Servers

--- a/tests/test_ec2plugin.py
+++ b/tests/test_ec2plugin.py
@@ -47,8 +47,8 @@ def test_request_fail(mock_logging, mock_request_get, mock_request_put):
         call('Unable to retrieve IMDSv2 token using fd00:ec2::254')
     ]
     expected_urls = [
-        'http://169.254.169.254/latest/meta-data/placement/availability-zone',
-        'http://[fd00:ec2::254]/latest/meta-data/placement/availability-zone'
+        'http://169.254.169.254/latest/meta-data/placement/region',
+        'http://[fd00:ec2::254]/latest/meta-data/placement/region'
     ]
     assert mock_logging.warning.call_args_list == [
         call('Falling back to IMDSv1'),
@@ -83,10 +83,10 @@ def test_request_fail_response_error(
     assert mock_logging.warning.called
     assert mock_logging.warning.call_args_list == [
         call('Falling back to IMDSv1'),
-        call('Unable to get availability zone metadata'),
+        call('Unable to get region metadata'),
         call('\tReturn code: 500'),
         call('\tMessage: Test server failure'),
-        call('Unable to get availability zone metadata'),
+        call('Unable to get region metadata'),
         call('\tReturn code: 500'),
         call('\tMessage: Test server failure')
     ]
@@ -95,32 +95,10 @@ def test_request_fail_response_error(
 # ----------------------------------------------------------------------------
 @patch('amazonec2.requests.put')
 @patch('amazonec2.requests.get')
-def test_request_succeed_gov_part(mock_request_get, mock_request_put):
+def test_request_succeed(mock_request_get, mock_request_put):
     """Test behavior with expected return value"""
-    mock_request_put.return_value = _get_expected_response_gov_part()
-    mock_request_get.return_value = _get_expected_response_gov_part()
-    result = ec2.generateRegionSrvArgs()
-    assert 'regionHint=us-gov-east-1' == result
-
-
-# ----------------------------------------------------------------------------
-@patch('amazonec2.requests.put')
-@patch('amazonec2.requests.get')
-def test_request_succeed_std_part(mock_request_get, mock_request_put):
-    """Test behavior with expected return value"""
-    mock_request_put.return_value = _get_expected_response_std_part()
-    mock_request_get.return_value = _get_expected_response_std_part()
-    result = ec2.generateRegionSrvArgs()
-    assert 'regionHint=us-east-1' == result
-
-
-# ----------------------------------------------------------------------------
-@patch('amazonec2.requests.put')
-@patch('amazonec2.requests.get')
-def test_request_succeed_local_zone(mock_request_get, mock_request_put):
-    """Test behavior with expected return value"""
-    mock_request_put.return_value = _get_expected_response_local_zone()
-    mock_request_get.return_value = _get_expected_response_local_zone()
+    mock_request_put.return_value = _get_expected_region_response()
+    mock_request_get.return_value = _get_expected_region_response()
     result = ec2.generateRegionSrvArgs()
     assert 'regionHint=us-east-1' == result
 
@@ -135,29 +113,11 @@ def _get_error_response():
 
 
 # ----------------------------------------------------------------------------
-def _get_expected_response_local_zone():
+def _get_expected_region_response():
     """Return an object mocking a expected response"""
     response = Response()
     response.status_code = 200
-    response.text = 'us-east-1-bos-1a'
-    return response
-
-
-# ----------------------------------------------------------------------------
-def _get_expected_response_gov_part():
-    """Return an object mocking a expected response"""
-    response = Response()
-    response.status_code = 200
-    response.text = 'us-gov-east-1a'
-    return response
-
-
-# ----------------------------------------------------------------------------
-def _get_expected_response_std_part():
-    """Return an object mocking a expected response"""
-    response = Response()
-    response.status_code = 200
-    response.text = 'us-east-1f'
+    response.text = 'us-east-1'
     return response
 
 


### PR DESCRIPTION
A while back EC2 IMDS gained a "region" endpoint to determine the region in which the instance is running. Using this endpoint directly allows us to drop the code that determined the region based on the information from the "availability-zone" end point. This simplifies the code and testing. Further this is more robust should AWS expand the zone naming as has happened in the past.