### PR TITLE
Spec clean

### DIFF
--- a/cloud-regionsrv-client.changes
+++ b/cloud-regionsrv-client.changes
@@ -1,7 +1,15 @@
 -------------------------------------------------------------------
 Upcoming 10.3.6
 
-- Update to 10.3.6 (jsc#PCT-471)
+- Update to 10.3.6 (jsc#PCT-471, bsc#1230615)
+  + Fix sudo setup
+    ~ permissions cloudguestregistryauth
+    ~ directory ownership /etc/sudoers.d
+  + spec file
+    ~ Remove traces of registry related entries on SLE 12
+  + Forward port
+    ~ fix-for-sles12-disable-registry.patch
+    ~ fix-for-sles12-no-trans_update.patch
   + Deregister non free extensions at registercloudguest --clean
   + Fix registry cleanup at registercloudguest --clean, don't remove files
   + Prevent duplicate search entries in registry setup

--- a/fix-for-sles12-disable-registry.patch
+++ b/fix-for-sles12-disable-registry.patch
@@ -1,4 +1,4 @@
---- lib/cloudregister/registerutils.py
+--- lib/cloudregister/registerutils.py.orig
 +++ lib/cloudregister/registerutils.py
 @@ -30,7 +30,8 @@ import stat
  import subprocess
@@ -6,11 +6,11 @@
  import time
 -import toml
 +# Disabled on SLE12
-+# import toml
++#import toml
  import yaml
  
  from collections import namedtuple
-@@ -74,11 +75,12 @@ def add_hosts_entry(smt_server):
+@@ -75,11 +76,12 @@ def add_hosts_entry(smt_server):
          smt_server.get_FQDN(),
          smt_server.get_name()
      )
@@ -21,14 +21,14 @@
 -        )
 +    # Disabled on SLE12
 +    # if smt_server.get_registry_FQDN():
-+    #     entry += '%s\t%s\n' % (
-+    #         smt_ip,
-+    #         smt_server.get_registry_FQDN()
-+    #     )
++    #    entry += '%s\t%s\n' % (
++    #        smt_ip,
++    #        smt_server.get_registry_FQDN()
++    #    )
  
      with open('/etc/hosts', 'a') as hosts_file:
          hosts_file.write(smt_hosts_entry_comment)
-@@ -900,6 +902,8 @@ def set_registries_conf(registry_fqdn):
+@@ -877,6 +879,8 @@ def set_registries_conf(registry_fqdn):
  
  # ----------------------------------------------------------------------------
  def get_registry_conf_file(container_path, container):
@@ -37,16 +37,16 @@
      registries_conf = {}
      try:
          with open(container_path, 'r') as registries_conf_file:
-@@ -945,6 +949,8 @@ def update_bashrc(content, mode):
- 
+@@ -923,6 +927,8 @@ def update_bashrc(content, mode):
  # ----------------------------------------------------------------------------
  def clean_registry_setup():
+     """Remove the data previously set to make the registry work."""
 +    # Disabled on SLE12
 +    return None
-     """Remove the data previously set to make the registry work."""
      smt = get_smt_from_store(__get_registered_smt_file_path())
      private_registry_fqdn = smt.get_registry_FQDN() if smt else ''
-@@ -1276,6 +1282,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
+     clean_registry_auth(private_registry_fqdn)
+@@ -1193,6 +1199,8 @@ def clean_registries_conf_docker(private
  # ----------------------------------------------------------------------------
  def write_registries_conf(registries_conf, container_path, container_name):
      """Write registries_conf content to container_path."""
@@ -55,9 +55,9 @@
      try:
          if container_name == 'podman':
              with open(container_path, 'w') as registries_conf_file:
---- usr/sbin/registercloudguest
+--- usr/sbin/registercloudguest.orig
 +++ usr/sbin/registercloudguest
-@@ -132,6 +132,8 @@ def setup_registry(registration_target, clean='registry'):
+@@ -134,6 +134,8 @@ def setup_registry(registration_target,
      clean == all -> cleans repository and registry setup
      clean == registry -> clean only registry artifacts
      """


### PR DESCRIPTION
Addresses various issues related to RPM build for SLE 15 and SLE 12 code streams.

- Fixes a bug (bsc#1230615) with the sudo rule setup, there is a separate issue with conflicting directory ownership, both issues are fixed
- The patch to disable registry related setup did not longer apply in SLE 12, fixed
- Removed registry related files from the SLE 12 package, since we do not support registry setup in SLE 12 these should not be there
- Cleaned up some rpmlint warnings for description length
