### PR TITLE
Fix LTSS registration

### DIFF
--- a/cloud-regionsrv-client.changes
+++ b/cloud-regionsrv-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Upcoming:
+
+- Update to 10.3.7 (bsc#1232770)
+  + Fix the product triplet for LTSS, it is always SLES-LTSS, not
+    $BASEPRODUCT-LTSS
+ 
+-------------------------------------------------------------------
 Tue Oct 29 13:44:21 UTC 2024 - Robert Schweikert <rjschwei@suse.com>
 
 - Update to 10.3.6 (jsc#PCT-471, bsc#1230615)

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -208,12 +208,10 @@ def setup_ltss_registration(
         print(message)
     else:
         base_product = utils.get_product_triplet(product)
-
-        # The name of the product to register is the LTSS variant for the
-        # registered base product. In theory other combinations are possible
-        # but we don't allow this for the moment
-        ltss_product_triplet = '{0}-LTSS/{1}/{2}'.format(
-            base_product.name, base_product.version, base_product.arch
+        # LTSS registration is always SLES even for variants such as
+        # SAP and HPC.
+        ltss_product_triplet = 'SLES-LTSS/{0}/{1}'.format(
+            base_product.version, base_product.arch
         )
 
         prod_reg = utils.register_product(


### PR DESCRIPTION
LTSS as an add on product has always SLES-LTSS as the product identifier in the product triplet even on other SLE products such as SLES For SAP and SLE HPC. Update the code to reflect this naming oddity.