### PR TITLE
Make sure to require container toolchain

### DIFF
--- a/cloud-regionsrv-client.changes
+++ b/cloud-regionsrv-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 13 16:12:23 UTC 2024 - Marcus Schäfer <marcus.schaefer@suse.com>
+
+- Update to 10.3.8 (bsc#1233333)
+  + Fix the package requirements for cloud-regionsrv-client
+
+-------------------------------------------------------------------
 Tue Nov  5 13:58:12 UTC 2024 - Robert Schweikert <rjschwei@suse.com>
 
 - Update to 10.3.7 (bsc#1232770)

--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -54,6 +54,14 @@ Requires:       %{pythons}-urllib3
 Requires:       %{pythons}-zypp-plugin
 %if 0%{?suse_version} > 1315
 Requires:       %{pythons}-toml
+# Add requirement for libcontainers-common to make sure all
+# podman related config files gets pulled in. We modify
+# /etc/containers/registries.conf
+Requires:       libcontainers-common
+# Add requirement for docker to make sure all docker related
+# config files gets pulled in. We modify
+# /etc/docker/daemon.json
+Requires:       docker
 %endif
 Requires:       regionsrv-certs
 Requires:       sudo


### PR DESCRIPTION
cloud-regionsrv-client modifies config files from the container toolchain, docker and podman. These files are provided by packages under certain conditions, e.g. permission and ownership. If the files are not present on the system when registercloudguest is called they are created under the umask() of the calling user which is not neccessarily correct. Because of that, this commit adds a requirement to the respective packages providing the config files such that any modifications retains the permission and ownership.