### PR TITLE
Update pipe to check for error message

### DIFF
--- a/cloud-regionsrv-client.changes
+++ b/cloud-regionsrv-client.changes
@@ -3,6 +3,7 @@ Wed Nov 13 16:12:23 UTC 2024 - Marcus Schäfer <marcus.schaefer@suse.com>
 
 - Update to 10.3.8 (bsc#1233333)
   + Fix the package requirements for cloud-regionsrv-client
+  + Follow changes to suseconnect error reporting from stdout to stderr
 
 -------------------------------------------------------------------
 Tue Nov  5 13:58:12 UTC 2024 - Robert Schweikert <rjschwei@suse.com>

--- a/integration_test-process.txt
+++ b/integration_test-process.txt
@@ -56,6 +56,14 @@ After installing the test package with "zypper in"
   + systemctl stop docker.service
   + zypper in podman
   + podman pull bci/bci-base
+  # The next test (until the end of this section) is still a bit flaky
+  # If it fails ignore if you are certain it is not broken because of changes
+  # in this code
+  + zypper in libcontainers-sles-mounts
+  + systemctl start containerbuild-regionsrv.service
+  + systemctl status containerbuild-regionsrv.service
+  + podman run --network host -it bci/bci-base
+  + zypper lr should have SLES repos
 - registercloudguest --clean
   + zypper lr has no repos
   On SLE 15

--- a/tests/test_registercloudguest.py
+++ b/tests/test_registercloudguest.py
@@ -2370,6 +2370,43 @@ def test_register_modules(mock_register_product):
     )
 
 
+@patch('cloudregister.registerutils.register_product')
+def test_register_modules_failed_credentials(mock_register_product):
+    prod_reg_type = namedtuple(
+        'prod_reg_type', ['returncode', 'output', 'error']
+    )
+
+    mock_register_product.return_value = prod_reg_type(
+        returncode=67,
+        output='',
+        error='missing system credentials try again'
+    )
+    extensions = [
+        {
+            'id': 23,
+            'name': 'SUSE Linux Enterprise Server LTSS',
+            'identifier': 'SLES-LTSS',
+            'former_identifier': 'SLES-LTSS',
+            'version': '15.4',
+            'release_type': None,
+            'release_stage': 'released',
+            'arch': 'x86_64',
+            'friendly_name':
+            'SUSE Linux Enterprise Server LTSS 15 SP4 x86_64',
+            'product_class': 'SLES15-SP4-LTSS-X86',
+            'free': False,
+            'repositories': [],
+            'product_type': 'extension',
+            'extensions': [],
+            'recommended': False,
+            'available': True
+        }
+    ]
+    register_cloud_guest.register_modules(
+        extensions, ['SLES-LTSS/15.4/x86_64'], 'reg_target', 'path', [], []
+    )
+
+
 @patch('cloudregister.registerutils.is_registry_registered')
 @patch('cloudregister.registerutils.get_credentials_file')
 @patch('cloudregister.registerutils.get_credentials')

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -86,11 +86,16 @@ def register_modules(
 
             if prod_reg.returncode:
                 registration_returncode = prod_reg.returncode
-                # Even on error SUSEConnect writes messages to stdout, go figure
+                # Older versions of SUSEConnect wrote error messages to stdout
                 error_message = prod_reg.output
+                if not error_message:
+                    error_message = prod_reg.error
                 if (
                     registration_returncode == 67 and
-                    'registration code' in error_message.lower()
+                    (
+                        'registration code' in error_message.lower() or
+                        'system credentials' in error_message.lower()
+                    )
                 ):
                     # SUSEConnect sets the following exit codes:
                     # 0:  Registration successful


### PR DESCRIPTION
suseconnect is changing to write error messages to STDERR instead of STDOUT, as such we need to check both pipes for the error message to avoid having a hard version dependency. Further the error message has changed and we need adjust for this condition as well.

Reference: https://github.com/SUSE/connect-ng/pull/272/files