### PR TITLE
Update patch files to be clean again

### DIFF
--- a/.github/workflows/ci-patch-validation.yml
+++ b/.github/workflows/ci-patch-validation.yml
@@ -11,6 +11,4 @@ jobs:
       - uses: actions/checkout@v3
       - name: Apply Patches
         run: |
-          patch -p0 < fix-for-sles12-disable-ipv6.patch
-          patch -p0 < fix-for-sles12-disable-registry.patch
-          patch -p0 < fix-for-sles12-no-trans_update.patch
+          ./apply_patches

--- a/apply_patches
+++ b/apply_patches
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ex
+
+for patch in *.patch;do
+    git apply "$patch"
+done
+
+find -name "*.orig" && false || true

--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -161,9 +161,9 @@ instance status are detected for PAYG vs. BYOS
 %prep
 %setup -q
 %if 0%{?suse_version} == 1315
-%patch -P 0
-%patch -P 1
-%patch -P 2
+%patch -P 0 -p1
+%patch -P 1 -p1
+%patch -P 2 -p1
 %endif
 
 %build

--- a/fix-for-sles12-disable-ipv6.patch
+++ b/fix-for-sles12-disable-ipv6.patch
@@ -1,6 +1,8 @@
---- lib/cloudregister/smt.py.orig
-+++ lib/cloudregister/smt.py
-@@ -109,6 +109,7 @@ class SMT:
+diff --git a/lib/cloudregister/smt.py b/lib/cloudregister/smt.py
+index 62c461a..19c7ebd 100644
+--- a/lib/cloudregister/smt.py
++++ b/lib/cloudregister/smt.py
+@@ -128,6 +128,7 @@ class SMT:
      # --------------------------------------------------------------------
      def get_ipv6(self):
          """Return the IP address"""

--- a/fix-for-sles12-disable-registry.patch
+++ b/fix-for-sles12-disable-registry.patch
@@ -1,5 +1,7 @@
---- lib/cloudregister/registerutils.py.orig
-+++ lib/cloudregister/registerutils.py
+diff --git a/lib/cloudregister/registerutils.py b/lib/cloudregister/registerutils.py
+index 7825ff0..5a712b0 100644
+--- a/lib/cloudregister/registerutils.py
++++ b/lib/cloudregister/registerutils.py
 @@ -30,7 +30,8 @@ import stat
  import subprocess
  import sys
@@ -46,7 +48,7 @@
      smt = get_smt_from_store(__get_registered_smt_file_path())
      private_registry_fqdn = smt.get_registry_FQDN() if smt else ''
      clean_registry_auth(private_registry_fqdn)
-@@ -1193,6 +1199,8 @@ def clean_registries_conf_docker(private
+@@ -1193,6 +1199,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
  # ----------------------------------------------------------------------------
  def write_registries_conf(registries_conf, container_path, container_name):
      """Write registries_conf content to container_path."""
@@ -55,9 +57,11 @@
      try:
          if container_name == 'podman':
              with open(container_path, 'w') as registries_conf_file:
---- usr/sbin/registercloudguest.orig
-+++ usr/sbin/registercloudguest
-@@ -134,6 +134,8 @@ def setup_registry(registration_target,
+diff --git a/usr/sbin/registercloudguest b/usr/sbin/registercloudguest
+index d32f036..c5f40d3 100755
+--- a/usr/sbin/registercloudguest
++++ b/usr/sbin/registercloudguest
+@@ -139,6 +139,8 @@ def setup_registry(registration_target, clean='registry'):
      clean == all -> cleans repository and registry setup
      clean == registry -> clean only registry artifacts
      """

--- a/fix-for-sles12-no-trans_update.patch
+++ b/fix-for-sles12-no-trans_update.patch
@@ -1,5 +1,7 @@
---- lib/cloudregister/registerutils.py
-+++ lib/cloudregister/registerutils.py
+diff --git a/lib/cloudregister/registerutils.py b/lib/cloudregister/registerutils.py
+index 7825ff0..6770e23 100644
+--- a/lib/cloudregister/registerutils.py
++++ b/lib/cloudregister/registerutils.py
 @@ -339,6 +339,8 @@ def get_register_cmd():
      """Determine which command we need to use to register the system"""
  


### PR DESCRIPTION
Fix patch files such that they apply clean and without producing a .orig file. Anytime a patch gets applied unclean it leaves a .orig file and the package build fails because of a new and unpackaged file. This commit fixes the patch files to apply clean again and also makes them git compliant