### PR TITLE
Fix build with applied patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 .cache
 **/*/__pycache__/
 .pytest_cache
+
+dist
+*.tar.bz2

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,15 @@ ifneq "$(verSpec)" "$(verSrc)"
     $(error "Version mismatch, will not take any action")
 endif
 
+package: tar
+	git checkout master
+	git pull
+	mkdir -p dist
+	rm -f dist/*
+	cp cloud-regionsrv-client* dist/
+	cp *.patch dist/
+	@echo "Find package files for submission below dist/"
+
 tar:
 	mkdir "$(nv)"
 	cp -r $(dirs) lib $(files) "$(nv)"

--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -67,6 +67,7 @@ Requires:       regionsrv-certs
 Requires:       sudo
 Requires:       zypper
 BuildRequires:  systemd
+BuildRequires:  findutils
 Conflicts:      container-suseconnect
 %if 0%{?suse_version} == 1315
 %{?systemd_requires}
@@ -164,6 +165,13 @@ instance status are detected for PAYG vs. BYOS
 %patch -P 0 -p1
 %patch -P 1 -p1
 %patch -P 2 -p1
+
+# %patch macro does not support to call patch such that it
+# does not create .orig files. Under certain conditions patch
+# creates them and this will break the build for files found
+# but not packaged
+find . -name *.orig -delete
+
 %endif
 
 %build


### PR DESCRIPTION
The %patch macro does not support to call patch such that it does not create .orig files. Under certain conditions patch creates them and this will break the build for files found but not packaged. From my perspective a successfully applied patch even with an offset drift is still acceptable and doesn't have to break the package build process. The way how we maintain the patches for SLE12 will always provide the offset drift as we are constantly working on other parts of the code. If the patch applies is checked via a github action per PR. Thus I believe the proposed patch should be ok.

Find an example build with this change applied here:

* https://build.suse.de/package/show/home:mschaefer/cloud-regionsrv-client