### PR TITLE
No need to for a versioned tarball

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ package: tar
 	git pull
 	mkdir -p dist
 	rm -f dist/*
+	mv cloud-regionsrv-client.tar.bz2 dist/
 	cp cloud-regionsrv-client* dist/
 	cp *.patch dist/
 	@echo "Find package files for submission below dist/"
@@ -25,7 +26,7 @@ tar:
 	find "$(nv)" -type f -name '*.py[co]' -delete -o -type d -name __pycache__ -delete
 	find "$(nv)" -path "*/lib/cloudregister.egg-info/*" -delete
 	find "$(nv)" -type d -name "cloudregister.egg-info" -delete
-	tar -cjf "$(nv).tar.bz2" "$(nv)"
+	tar -cjf "cloud-regionsrv-client.tar.bz2" "$(nv)"
 	rm -rf "$(nv)"
 
 install:

--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -30,7 +30,7 @@ Summary:        Cloud Environment Guest Registration
 License:        LGPL-3.0-only
 Group:          Productivity/Networking/Web/Servers
 URL:            http://www.github.com/SUSE-Enceladus/cloud-regionsrv-client
-Source0:        %{name}-%{version}.tar.bz2
+Source0:        %{name}.tar.bz2
 # PATCH-FIX-SLES12 bsc#1203382 fix-for-sles12-disable-ipv6.patch
 Patch0:         fix-for-sles12-disable-ipv6.patch
 # PATCH-FIX-SLES12 fix-for-sles12-disable-registry.patch


### PR DESCRIPTION
The way the source tarball is created produces a versioned source tree inside of the tarball. There is no need to duplicate this information in the file name of the tarfile. Providing a consistent source file name prevents issues with package maintenance in a way that on each version bump a new source file needs to be deleted/added and also prevents issues with multiple source files still available if the packager forgot to delete the old one. Also spec file inconsistencies if only a new source tarball gets committed but the spec and the old source was forgotten to be updated/removed will no longer occur.