### PR TITLE
Clean up when package gets removed

### DIFF
--- a/cloud-regionsrv-client.changes
+++ b/cloud-regionsrv-client.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+NEXT version
+
+- Update version to
+  + Remove repositories when the package is being removed
+    We do not want to leave repositories behind refering to the plugin that
+    is being removed when the package gets removed (bsc#1240310, bsc#1240311)
+
+-------------------------------------------------------------------
 Tue Dec  3 17:21:52 UTC 2024 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
 
 - Update to 10.3.11 (bsc#1234050)

--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -210,6 +210,15 @@ gzip %{buildroot}/%{_mandir}/man1/*
 %pre addon-azure
 %service_add_pre regionsrv-enabler.timer
 
+%preun
+# Do not run during an upgrade process
+# When the package is removed we need to clean up or we will leave
+# repositories with "plugin://" behind while the plugin we supply is
+# being removed (bsc#1240310)
+if [ "$1" -eq 0 ]; then
+    %{_sbindir}/registercloudguest --clean
+fi
+
 %post
 # Scripts need access to the update infrastructure, do not execute them
 # in the build service.


### PR DESCRIPTION
At present when the package gets removed we leave repositories behind that point to the plugin that is supplied with this package. However with the removal of this package the plugin is also removed. This leaves the system in a state that is difficult to recover from and requires manual clean up. We clean up the registration when the package is removed to avoid this problem.