### PR TITLE
Turn docker into an optional setup

### DIFF
--- a/cloud-regionsrv-client.changes
+++ b/cloud-regionsrv-client.changes
@@ -5,7 +5,9 @@ NEXT version
   + Remove repositories when the package is being removed
     We do not want to leave repositories behind refering to the plugin that
     is being removed when the package gets removed (bsc#1240310, bsc#1240311)
-
+  + Turn docker into an optional setup
+    Change the Requires into a Recommends and adapt the code accordingly
+    
 -------------------------------------------------------------------
 Tue Dec  3 17:21:52 UTC 2024 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
 

--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -58,10 +58,10 @@ Requires:       %{pythons}-toml
 # podman related config files gets pulled in. We modify
 # /etc/containers/registries.conf
 Requires:       libcontainers-common
-# Add requirement for docker to make sure all docker related
-# config files gets pulled in. We modify
+# Add recommendation for docker to make sure all docker related
+# config files get pulled in. If present we modify
 # /etc/docker/daemon.json
-Requires:       docker
+Recommends:     docker
 %endif
 Requires:       regionsrv-certs
 Requires:       sudo

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -734,14 +734,16 @@ def get_credentials(credentials_file):
 
 
 # ----------------------------------------------------------------------------
-def setup_registry(registry_fqdn, username, password):
-    """Set all the necessary parts for the registry,
-       returns True if the setup completed, False otherwise."""
+def prepare_registry_setup(registry_fqdn, username, password):
+    """
+    Setup registry auth token and environment file in preparation
+    for the individual container registry setup.
+    """
     os.makedirs(os.path.dirname(REGISTRY_CREDENTIALS_PATH), exist_ok=True)
 
     return (
         set_registry_auth_token(registry_fqdn, username, password) and
-        set_container_engines_env_vars() and set_registries_conf(registry_fqdn)
+        set_container_engines_env_vars()
     )
 
 
@@ -862,20 +864,6 @@ def set_container_engines_env_vars():
 
 
 # ----------------------------------------------------------------------------
-def set_registries_conf(registry_fqdn):
-    """Add the registry container engines search configuration."""
-    container_engines_conf_set = (
-        __set_registries_conf_podman(registry_fqdn) and
-        __set_registries_conf_docker(registry_fqdn)
-    )
-    suma_registry_conf_set = True
-    if is_suma_instance():
-        suma_registry_conf_set = __set_registry_fqdn_suma(registry_fqdn)
-
-    return container_engines_conf_set and suma_registry_conf_set
-
-
-# ----------------------------------------------------------------------------
 def get_registry_conf_file(container_path, container):
     registries_conf = {}
     try:
@@ -888,7 +876,7 @@ def get_registry_conf_file(container_path, container):
     except IOError as error:
         logging.info(str(error))
         action = 'open'
-    except json.decoder.JSONDecodeError:
+    except (json.decoder.JSONDecodeError, toml.decoder.TomlDecodeError):
         action = 'parse'
 
     logging.info(
@@ -1151,7 +1139,7 @@ def clean_registries_conf_podman(private_registry_fqdn):
 # ----------------------------------------------------------------------------
 def clean_registries_conf_docker(private_registry_fqdn):
     """Clean up the registry content from the DOCKER_CONFIG_PATH file."""
-    if not os.path.exists(DOCKER_CONFIG_PATH):
+    if not is_docker_present():
         return True
 
     docker_cfg_json, failed = get_registry_conf_file(
@@ -1209,6 +1197,7 @@ def write_registries_conf(registries_conf, container_path, container_name):
         action = 'write'
 
     logging.error('Could not %s %s' % (action, container_path))
+    return False
 
 
 # ----------------------------------------------------------------------------
@@ -1867,6 +1856,11 @@ def is_registry_registered(registry_server_name):
        and os.path.exists(registry_auth_file):
         return True
     return False
+
+
+# ----------------------------------------------------------------------------
+def is_docker_present():
+    return os.path.exists(DOCKER_CONFIG_PATH)
 
 
 # ----------------------------------------------------------------------------
@@ -2587,7 +2581,7 @@ def __mv_file_backup(filename):
 
 
 # ----------------------------------------------------------------------------
-def __set_registries_conf_podman(private_registry_fqdn):
+def set_registries_conf_podman(private_registry_fqdn):
     """Set the registry search order for Podman."""
     registries_conf = {}
     if os.path.exists(REGISTRIES_CONF_PATH):
@@ -2648,51 +2642,50 @@ def __set_registries_conf_podman(private_registry_fqdn):
 
 
 # ----------------------------------------------------------------------------
-def __set_registries_conf_docker(private_registry_fqdn):
+def set_registries_conf_docker(private_registry_fqdn):
     suse_registry_url = 'https://{0}'.format(SUSE_REGISTRY)
     private_registry_url = 'https://{0}'.format(private_registry_fqdn)
     docker_cfg_json = {}
     registry_mirrors = []
-    os.makedirs(os.path.dirname(DOCKER_CONFIG_PATH), exist_ok=True)
-    if os.path.exists(DOCKER_CONFIG_PATH):
+    if is_docker_present():
         docker_cfg_json, failed = get_registry_conf_file(
             DOCKER_CONFIG_PATH, 'docker'
         )
         if failed:
             return False
 
-    modified_by_us = False
-    # Setup registry-mirrors in docker daemon.json
-    registry_mirrors = docker_cfg_json.get('registry-mirrors', [])
-    if private_registry_url not in registry_mirrors:
-        # susecloud registry not added, always place it first
-        registry_mirrors.insert(0, private_registry_url)
-        modified_by_us = True
+        modified_by_us = False
+        # Setup registry-mirrors in docker daemon.json
+        registry_mirrors = docker_cfg_json.get('registry-mirrors', [])
+        if private_registry_url not in registry_mirrors:
+            # susecloud registry not added, always place it first
+            registry_mirrors.insert(0, private_registry_url)
+            modified_by_us = True
 
-    if suse_registry_url not in registry_mirrors:
-        # the suse registry search is provided by the libcontainers-common
-        # package. For the case when we cannot find any suse registry we
-        # append it after the susecloud registry
-        #
-        # Note: docker search is disabled for Docker server side !
-        private_registry_index = registry_mirrors.index(
-            private_registry_url
-        )
-        registry_mirrors.insert(
-            private_registry_index + 1, suse_registry_url
-        )
-        modified_by_us = True
+        if suse_registry_url not in registry_mirrors:
+            # the suse registry search is provided by the docker
+            # package. For the case when we cannot find any suse registry we
+            # append it after the susecloud registry
+            #
+            # Note: docker search is disabled for Docker server side !
+            private_registry_index = registry_mirrors.index(
+                private_registry_url
+            )
+            registry_mirrors.insert(
+                private_registry_index + 1, suse_registry_url
+            )
+            modified_by_us = True
 
-    # write registry setup if modified by us
-    if modified_by_us:
-        docker_cfg_json['registry-mirrors'] = registry_mirrors
-        return write_registries_conf(
-            docker_cfg_json, DOCKER_CONFIG_PATH, 'docker'
-        )
+        # write registry setup if modified by us
+        if modified_by_us:
+            docker_cfg_json['registry-mirrors'] = registry_mirrors
+            return write_registries_conf(
+                docker_cfg_json, DOCKER_CONFIG_PATH, 'docker'
+            )
 
 
 # ----------------------------------------------------------------------------
-def __set_registry_fqdn_suma(private_registry_fqdn):
+def set_registry_fqdn_suma(private_registry_fqdn):
     """Set the registry FQDN for SUMa SUMA_REGISTRY_CONF_PATH file."""
     suma_yaml_content = {}
     os.makedirs(os.path.dirname(SUMA_REGISTRY_CONF_PATH), exist_ok=True)

--- a/usr/sbin/registercloudguest
+++ b/usr/sbin/registercloudguest
@@ -145,7 +145,41 @@ def setup_registry(registration_target, clean='registry'):
         utils.get_credentials_file(registration_target)
     )
     registry_fqdn = registration_target.get_registry_FQDN()
+
+    with_docker = utils.is_docker_present()
+    if not with_docker:
+        logging.info(
+            'docker config file {} not found. '
+            'Registration for docker skipped. '
+            'Install docker to add docker support.'.format(
+                utils.DOCKER_CONFIG_PATH
+            )
+        )
+
     if utils.is_registry_registered(registry_fqdn):
+        if with_docker:
+            # Special handling for the docker case:
+            #
+            # When docker is present we perform the registry configuration
+            # for the docker container engine. This may cause calling the
+            # setup routine even though docker was setup before. However,
+            # the code will only effectively write a new registry setup
+            # if the required modifications are not included.
+            logging.info('Adding docker support')
+            docker_setup_ok = utils.set_registries_conf_docker(registry_fqdn)
+
+            # docker_setup_ok will take a True/False value on a real
+            # action that happened. In any other case a None value is
+            # present which indicates no action was performed.
+            if docker_setup_ok is False:
+                print(
+                    'Registration failed(docker), see {0} for details'.format(
+                        LOG_FILE
+                    ), file=sys.stderr
+                )
+                sys.exit(1)
+            elif docker_setup_ok is True:
+                print('Successfully added docker to the registry setup')
         logging.info(
             'Instance is setup to access container registry, nothing to do'
         )
@@ -154,7 +188,16 @@ def setup_registry(registration_target, clean='registry'):
         'Adding registry setup to instance, all existing shell '
         'sessions must be restarted to use the registry.'
     )
-    if not utils.setup_registry(registry_fqdn, user, password):
+    registry_setup_ok = False
+    if utils.prepare_registry_setup(registry_fqdn, user, password):
+        logging.info('Adding podman support')
+        registry_setup_ok = utils.set_registries_conf_podman(registry_fqdn)
+        if with_docker:
+            logging.info('Adding docker support')
+            registry_setup_ok = utils.set_registries_conf_docker(registry_fqdn)
+        if utils.is_suma_instance():
+            registry_setup_ok = utils.set_registry_fqdn_suma(registry_fqdn)
+    if not registry_setup_ok:
         if clean == 'all':
             cleanup()
         elif clean == 'registry':


### PR DESCRIPTION
The simple docker requirement in the spec file of the cloud-regionsrv-client package has turned into a big problem for customers who don't want docker on their systems. This commit makes docker a recommended package and refactors the registration setup code in a way that docker becomes an optional part of the setup procedure. With each call of registercloudguest a check is made to see if docker is installed. If it is installed the current setup is updated with a docker related configuration if not already done