### PR TITLE
Properly handle the root argument for zypper

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -1628,7 +1628,7 @@ def get_zypper_target_root():
     """
     zypper_cmd = get_zypper_command()
     target_root = ''
-    for root_arg in ('-R', '--root'):
+    for root_arg in ('-R ', '--root '):
         if zypper_cmd and root_arg in zypper_cmd:
             target_root = zypper_cmd.split(root_arg)[-1].split()[0].strip()
             break


### PR DESCRIPTION
When parsing the zypper command line to determine if we operate on a different root system we did not account for the space in the argument list to indicate the directory. This resulted in incorrect parsing results for packages with "-R" in the package name. Resulting in failed package updates.