### PR TITLE
Update CI testing action

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -10,10 +10,6 @@ jobs:
       matrix:
         python-version: ["3.11"]
         os: [ubuntu-latest]
-        include:
-          # Use ubuntu 20.04 for python 3.6 (dropped from later versions)
-          - python-version: 3.6
-            os: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
ubuntu-20.04 is a deprecated target on the github actions matrix and can no longer be used. We referenced this distro because it was the only one providing the old python 3.6 stack. This commit drops the 3.6 tests and therefore the SLE15 (3.6) testing pipeline. This code also has to support SLE12 (3.4) but we never had a pipeline for that old python versions. So for the future we have to manually make sure the code in this project works for 3.6 and 3.4 or come up with our own github runners.