### PR TITLE
Explicit confirm cert request

### DIFF
--- a/lib/cloudregister/smt.py
+++ b/lib/cloudregister/smt.py
@@ -294,13 +294,12 @@ class SMT:
                     if cert_res:
                         if cert_res.status_code == 200:
                             logging.info(
-                                'Request to %s succeeded' %
-                                (cert_url + cert_name)
+                                'Request to %s%s succeeded' %
+                                (cert_url, cert_name)
                             )
                             return cert_res
 
                         logging.warning(
-                            'Request to %s failed: %s' %
-                            ((cert_url + cert_name),
-                             cert_res.status_code)
+                            'Request to %s%s failed: %s' %
+                            (cert_url, cert_name, cert_res.status_code)
                         )

--- a/lib/cloudregister/smt.py
+++ b/lib/cloudregister/smt.py
@@ -291,14 +291,15 @@ class SMT:
                         else:
                             ip = self.get_ipv4()
                         logging.warning('Server %s is unreachable' % ip)
-                    if cert_res and cert_res.status_code == 200:
-                        logging.info(
-                            'Request to %s succeeded' % (cert_url + cert_name)
-                        )
-                        return cert_res
-
                     if cert_res:
-                        logging.warn(
+                        if cert_res.status_code == 200:
+                            logging.info(
+                                'Request to %s succeeded' %
+                                (cert_url + cert_name)
+                            )
+                            return cert_res
+
+                        logging.warning(
                             'Request to %s failed: %s' %
                             ((cert_url + cert_name),
                              cert_res.status_code)

--- a/lib/cloudregister/smt.py
+++ b/lib/cloudregister/smt.py
@@ -280,9 +280,6 @@ class SMT:
                         cert_res = requests.get(
                             cert_url + cert_name, verify=False
                         )
-                        logging.info(
-                            'Request to %s succeeded' % (cert_url + cert_name)
-                        )
                     except Exception:
                         # No response from server
 
@@ -295,4 +292,15 @@ class SMT:
                             ip = self.get_ipv4()
                         logging.warning('Server %s is unreachable' % ip)
                     if cert_res and cert_res.status_code == 200:
+                        logging.info(
+                            'Request to %s succeeded' % (cert_url + cert_name)
+                        )
                         return cert_res
+
+                    if cert_res:
+                        logging.warn(
+                            'Request to %s failed: %s' %
+                            ((cert_url + cert_name),
+                             cert_res.status_code)
+                        )
+

--- a/lib/cloudregister/smt.py
+++ b/lib/cloudregister/smt.py
@@ -278,8 +278,11 @@ class SMT:
                 for cert_url in self._check_urls.values():
                     try:
                         cert_res = requests.get(
-                                cert_url + cert_name, verify=False
-                            )
+                            cert_url + cert_name, verify=False
+                        )
+                        logging.info(
+                            'Request to %s succeeded' % (cert_url + cert_name)
+                        )
                     except Exception:
                         # No response from server
 

--- a/lib/cloudregister/smt.py
+++ b/lib/cloudregister/smt.py
@@ -303,4 +303,3 @@ class SMT:
                             ((cert_url + cert_name),
                              cert_res.status_code)
                         )
-

--- a/tests/test_smt.py
+++ b/tests/test_smt.py
@@ -210,8 +210,8 @@ def test_get_cert_not_found(
     mock_cert_pull.return_value = response
     smt = SMT(etree.fromstring(smt_data_ipv46))
     assert smt.get_cert() is None
-    assert mock_logging.warn.called
-    mock_logging.warn.assert_called_with(
+    assert mock_logging.warning.called
+    mock_logging.warning.assert_called_with(
         'Request to http://192.168.1.1/rmt.crt failed: 404'
     )
 

--- a/tests/test_smt.py
+++ b/tests/test_smt.py
@@ -209,7 +209,7 @@ def test_get_cert_not_found(
     response.status_code = '404'
     mock_cert_pull.return_value = response
     smt = SMT(etree.fromstring(smt_data_ipv46))
-    assert smt.get_cert() == None
+    assert smt.get_cert() is None
     assert mock_logging.warn.called
     mock_logging.warn.assert_called_with(
         'Request to http://192.168.1.1/rmt.crt failed: 404'

--- a/tests/test_smt.py
+++ b/tests/test_smt.py
@@ -199,6 +199,27 @@ def test_get_cert_no_match_cert(mock_cert_pull, mock_logging, mock_load_cert):
 @patch('smt.logging')
 @patch.object(SMT, 'get_fingerprint')
 @patch('smt.requests.get')
+def test_get_cert_not_found(
+    mock_cert_pull,
+    mock_get_fingerprint,
+    mock_logging
+):
+    """Test get cert."""
+    response = Response()
+    response.status_code = '404'
+    mock_cert_pull.return_value = response
+    smt = SMT(etree.fromstring(smt_data_ipv46))
+    assert smt.get_cert() == None
+    assert mock_logging.warn.called
+    mock_logging.warn.assert_called_with(
+        'Request to http://192.168.1.1/rmt.crt failed: 404'
+    )
+
+
+# ----------------------------------------------------------------------------
+@patch('smt.logging')
+@patch.object(SMT, 'get_fingerprint')
+@patch('smt.requests.get')
 def test_get_cert(
     mock_cert_pull,
     mock_get_fingerprint,

--- a/tests/test_smt.py
+++ b/tests/test_smt.py
@@ -196,11 +196,13 @@ def test_get_cert_no_match_cert(mock_cert_pull, mock_logging, mock_load_cert):
 
 
 # ----------------------------------------------------------------------------
+@patch('smt.logging')
 @patch.object(SMT, 'get_fingerprint')
 @patch('smt.requests.get')
 def test_get_cert(
     mock_cert_pull,
-    mock_get_fingerprint
+    mock_get_fingerprint,
+    mock_logging
 ):
     """Test get cert."""
     response = Response()
@@ -213,6 +215,10 @@ def test_get_cert(
     mock_get_fingerprint.return_value = x509.get_fingerprint('sha1')
     smt = SMT(etree.fromstring(smt_data_ipv46))
     assert smt.get_cert() == response.text
+    assert mock_logging.info.called
+    mock_logging.info.assert_called_with(
+        'Request to http://[fc00::1]/smt.crt succeeded'
+    )
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
In order to have more information in the logs for debugging purposes,
add info logging when we succeed requesting a cert to the update
infrastructure server

This is related to bsc#1242435