### PR TITLE
Update SUMA and MLM check

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -2314,12 +2314,12 @@ def is_suma_instance():
         'manager-server.prod',
         'sle-micro.prod'
     ]
-    num_prod_matches = [
+    prod_matches = [
         suma_prod for product in products
-        for suma_prod in suma_prods if suma_prod in Path(product.lower()).name
+        for suma_prod in suma_prods if suma_prod in product.lower()
     ]
 
-    return len(num_prod_matches) == len(suma_prods)
+    return len(prod_matches) == len(suma_prods)
 
 
 # ----------------------------------------------------------------------------

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -2308,13 +2308,13 @@ def is_suma_instance():
     """Return True if there is a match for SUMA and SLE-Micro products,
     otherwise False."""
     products = glob.glob('/etc/products.d/*.prod')
+    num_matches = 0
     # suse-manager-server changed to
     # multi-linux-manager-server, check both (bsc#1243437)
-    num_matches = 0
     suma_prods = [
-        '/etc/products.d/suse-manager-server.prod',
-        '/etc/products.d/multi-linux-manager-server.prod',  # SUMA 5.1
-        '/etc/products.d/sle-micro.prod',
+        '/etc/products.d/suse-manager-server.prod',  # SUMA 5.0
+        '/etc/products.d/multi-linux-manager-server.prod',  # SUMA 5.1 (MLM)
+        '/etc/products.d/sle-micro.prod',  # Micro < 6.1
         '/etc/products.d/sl-micro.prod'  # Micro 6.1 and 6.2
     ]
     for product in products:

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -2313,9 +2313,9 @@ def is_suma_instance():
     num_matches = 0
     suma_prods = [
         '/etc/products.d/suse-manager-server.prod',
-        '/etc/products.d/multi-linux-manager-server.prod', # SUMA 5.1
+        '/etc/products.d/multi-linux-manager-server.prod',  # SUMA 5.1
         '/etc/products.d/sle-micro.prod',
-        '/etc/products.d/sl-micro.prod' # Micro 6.1 and 6.2
+        '/etc/products.d/sl-micro.prod'  # Micro 6.1 and 6.2
     ]
     for product in products:
         if product.lower() in suma_prods:

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -2308,16 +2308,18 @@ def is_suma_instance():
     """Return True if there is a match for SUMA and SLE-Micro products,
     otherwise False."""
     products = glob.glob('/etc/products.d/*.prod')
-    num_matches = 0
+    # suse-manager-server changed to
+    # multi-linux-manager-server, check both (bsc#1243437)
     suma_prods = [
-        '/etc/products.d/suse-manager-server.prod',
-        '/etc/products.d/sle-micro.prod'
+        'manager-server.prod',
+        'sle-micro.prod'
     ]
-    for product in products:
-        if product.lower() in suma_prods:
-            num_matches += 1
+    num_prod_matches = [
+        suma_prod for product in products
+        for suma_prod in suma_prods if suma_prod in Path(product.lower()).name
+    ]
 
-    return num_matches == len(suma_prods)
+    return len(num_prod_matches) == len(suma_prods)
 
 
 # ----------------------------------------------------------------------------

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -2310,16 +2310,17 @@ def is_suma_instance():
     products = glob.glob('/etc/products.d/*.prod')
     # suse-manager-server changed to
     # multi-linux-manager-server, check both (bsc#1243437)
+    num_matches = 0
     suma_prods = [
-        'manager-server.prod',
-        'sle-micro.prod'
+        '/etc/products.d/suse-manager-server.prod',
+        '/etc/products.d/multi-linux-manager-server.prod',
+        '/etc/products.d/sle-micro.prod'
     ]
-    prod_matches = [
-        suma_prod for product in products
-        for suma_prod in suma_prods if suma_prod in product.lower()
-    ]
+    for product in products:
+        if product.lower() in suma_prods:
+            num_matches += 1
 
-    return len(prod_matches) == len(suma_prods)
+    return num_matches == len(suma_prods) - 1
 
 
 # ----------------------------------------------------------------------------

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -2313,14 +2313,17 @@ def is_suma_instance():
     num_matches = 0
     suma_prods = [
         '/etc/products.d/suse-manager-server.prod',
-        '/etc/products.d/multi-linux-manager-server.prod',
-        '/etc/products.d/sle-micro.prod'
+        '/etc/products.d/multi-linux-manager-server.prod', # SUMA 5.1
+        '/etc/products.d/sle-micro.prod',
+        '/etc/products.d/sl-micro.prod' # Micro 6.1 and 6.2
     ]
     for product in products:
         if product.lower() in suma_prods:
             num_matches += 1
 
-    return num_matches == len(suma_prods) - 1
+    # only one Micro + SUMA product possible at the same time for
+    # a SUMA instance
+    return num_matches == 2
 
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Before MLM the SUMA product was named 'SUSE-Manager-Server.prod', 
now it is called 'Multi-Linux-Manager-Server.prod', we need to check both products

This fixes bsc#1243437