### PR TITLE
Add delay if registration is not completed during fail over

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -1902,7 +1902,7 @@ def is_registration_completed():
     """Indicate whether a registration is in process or completed based on the
        marker file. Note it is the responsibility of the process to properly
        manage the marker file"""
-    return os.path.exists(
+    return os.path.isfile(
         os.path.join(get_state_dir(), REGISTRATION_COMPLETED_MARKER)
     )
 


### PR DESCRIPTION
When getting an update infrastructure server and there is a fail over and registration is not completed, we wait the regsharing time to be triggered plus 10 seconds to make sure the credentials are shared and sync'ed between the siblings

This is part of the changes to fix bsc#1242435