### PR TITLE
Remove entries from /etc/hosts file when cleanup

### DIFF
--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -2110,6 +2110,20 @@ def switch_services_to_plugin():
 
 
 # ----------------------------------------------------------------------------
+def get_domain_name_from_region_server():
+    cfg = get_config()
+    # pick the first region server from the list
+    region_rmt_server_data = fetch_smt_data(cfg, None)
+    region_rmt_server = None
+    for child in region_rmt_server_data:
+        region_rmt_server = smt.SMT(child, True)
+        break
+
+    if region_rmt_server:
+        return region_rmt_server.get_domain_name()
+
+
+# ----------------------------------------------------------------------------
 def remove_registration_data():
     """Reset the instance to an unregistered state"""
     clear_rmt_as_scc_proxy_flag()
@@ -2118,7 +2132,12 @@ def remove_registration_data():
     if not user:
         if not is_new_registration():
             logging.info('No credentials, nothing to do server side')
+        domain_name = get_domain_name_from_region_server()
+        if domain_name:
+            logging.info('Cleaning up /etc/hosts for %s', domain_name)
+            clean_hosts_file(domain_name)
         return
+
     auth_creds = HTTPBasicAuth(user, password)
     if os.path.exists(smt_data_file):
         smt = get_smt_from_store(smt_data_file)
@@ -2172,6 +2191,10 @@ def remove_registration_data():
         __remove_repo_artifacts('suse.com')
     else:
         logging.info('No current registration server set.')
+        domain_name = get_domain_name_from_region_server()
+        if domain_name:
+            logging.info('Cleaning up /etc/hosts for %s', domain_name)
+            clean_hosts_file(domain_name)
 
 
 # ----------------------------------------------------------------------------

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -2118,9 +2118,8 @@ def get_domain_name_from_region_server():
     cfg = get_config()
     region_rmt_server_data = fetch_smt_data(cfg, None)
     for child in region_rmt_server_data:
-        # use any region server from the list
-        # the domain name should be the same for all the region servers
-        # no need to loop over all of them
+        # use the domain name from the first child of the region server response
+        # no need to loop over all of the 3 entries/siblings
         return smt.SMT(child, True).get_domain_name()
 
 

--- a/tests/test_registercloudguest.py
+++ b/tests/test_registercloudguest.py
@@ -87,6 +87,7 @@ def test_register_cloud_guest_no_regcode_email():
         assert register_cloud_guest.main(fake_args) is None
 
 
+@patch('cloudregister.registerutils.clean_hosts_file')
 @patch('cloudregister.registerutils.clean_non_free_extensions')
 @patch('register_cloud_guest.time.sleep')
 @patch('cloudregister.registerutils.get_config')
@@ -98,7 +99,7 @@ def test_register_cloud_guest_no_regcode_email():
 def test_register_cloud_guest_cleanup(
     mock_clean_reg_setup, mock_remove_reg_data, mock_clean_smt_cache,
     mock_clear_reg_flag, mock_framework_id,  mock_get_config, mock_time_sleep,
-    mock_clean_non_free_extensions
+    mock_clean_non_free_extensions, mock_clean_hosts_file
 ):
     fake_args = SimpleNamespace(
         clean_up=True,

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -3065,7 +3065,9 @@ def test_switch_services_to_plugin_unlink_service(
 
 @patch('cloudregister.registerutils.fetch_smt_data')
 @patch('cloudregister.registerutils.get_config')
-def test_foo(mock_get_config, mock_fetch_smt_data):
+def test_get_domain_name_from_region_server(
+    mock_get_config, mock_fetch_smt_data
+):
     smt_xml = dedent('''\
     <regionSMTdata>
       <smtInfo fingerprint="99:88:77:66"


### PR DESCRIPTION
Due to certain conditions, the /etc/hosts file keeps update infrastructure and registry entries when they should be removed

This change fixes bsc#1244152