### PR TITLE
Fix code state

### DIFF
--- a/cloud-regionsrv-client.changes
+++ b/cloud-regionsrv-client.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+
+- Update version to $NEXT
+  + Use region server IP addresses to determine Internet access rather
+    than a generic address. Region server IP addresses may not be blocked
+    in the network construct. (bsc#1245305)
+
+-------------------------------------------------------------------
 Tue Apr 29 12:31:05 UTC 2025 - Robert Schweikert <rjschwei@suse.com>
 
 - Update version to 10.4.0

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -531,9 +531,9 @@ def fetch_smt_data(cfg, proxies, quiet=False):
                 region_servers_dns.append(srv_id)
                 continue
             if isinstance(ip_addr, ipaddress.IPv6Address):
-                region_servers_ipv6.append(ip_addr)
+                region_servers_ipv6.append(srv_id)
             else:
-                region_servers_ipv4.append(ip_addr)
+                region_servers_ipv4.append(srv_id)
         random.shuffle(region_servers_ipv4)
         random.shuffle(region_servers_ipv6)
         if has_ipv6_access(region_servers_ipv6):
@@ -1688,7 +1688,8 @@ def has_network_access_by_ip_address(server_ip):
 def has_rmt_ipv6_access(smt):
     """IPv6 access is possible if we have an SMT server that has an IPv6
        address and it can be accessed over IPv6"""
-    if not has_ipv6_access() or not smt.get_ipv6():
+    smt_ipv6 = smt.get_ipv6()
+    if not smt_ipv6 or not has_ipv6_access([smt_ipv6]):
         return False
     logging.info('Attempt to access update server over IPv6')
     protocol = 'http'  # Default for backward compatibility

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -589,7 +589,8 @@ def fetch_smt_data(cfg, proxies, quiet=False):
                 try:
                     url = 'https://%s/%s' % (srvName, api)
                     # Per rfc3986 IPv6 addresses in a URI are enclosed in []
-                    if isinstance(srv, ipaddress.IPv6Address):
+                    ip_addr = ipaddress.ip_address(srv)
+                    if isinstance(ip_addr, ipaddress.IPv6Address):
                         url = 'https://[%s]/%s' % (srvName, api)
                     response = requests.get(
                         url,

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -1855,13 +1855,13 @@ def test_fetch_smt_data_api_exception(
     assert mock_logging.error.call_args_list == [
         call('\tNo response from: fc00::11'),
         call('\tNone of the servers responded'),
-        call("\tAttempted: [IPv6Address('fc00::11')]"),
+        call("\tAttempted: ['fc00::11']"),
         call('\tNo response from: fc00::11'),
         call('\tNone of the servers responded'),
-        call("\tAttempted: [IPv6Address('fc00::11')]"),
+        call("\tAttempted: ['fc00::11']"),
         call('\tNo response from: fc00::11'),
         call('\tNone of the servers responded'),
-        call("\tAttempted: [IPv6Address('fc00::11')]"),
+        call("\tAttempted: ['fc00::11']"),
         call('Request not answered by any server after 3 attempts'),
         call('Exiting without registration')
     ]

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -1755,7 +1755,9 @@ def test_fetch_smt_data_api_no_valid_ip(
     )
     response.text = smt_xml
     mock_request_get.side_effect = [response, response]
-    mock_ipaddress_ip_address.side_effect = [ValueError, ValueError]
+    mock_ipaddress_ip_address.side_effect = [
+        ValueError, ValueError, IPv6Address
+    ]
     mock_socket_create_connection.side_effect = OSError
     mock_get_region_server_ips.return_value = \
         ['1.1.1.1'], ['fc11::2'], ['foo']


### PR DESCRIPTION
Code was not releasable due to untested changes being merged triggering an error when we were checking for access to the network for the IPv6 protocol. One error was that IPAdress objects were passed for socket creation instead of a string and the other error was that we did not pass an address at all.