### PR TITLE
Appease the build service

### DIFF
--- a/cloud-regionsrv-client.changes
+++ b/cloud-regionsrv-client.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Fri Jul 25 11:06:58 UTC 2025 - Robert Schweikert <rjschwei@suse.com>
+
+- Update version to 10.5.1
+  + Fix issue with picking up configured server names from the
+    regionsrv config file. Previously only IP addresses were collected
+  + Update scriptlet for package uninstall to avoid issues in the
+    build service
+
+-------------------------------------------------------------------
 Wed Jul 23 19:38:28 UTC 2025 - Robert Schweikert <rjschwei@suse.com>
 
 - Update version to 10.5.0

--- a/cloud-regionsrv-client.spec
+++ b/cloud-regionsrv-client.spec
@@ -233,6 +233,17 @@ fi
 if [ "$1" -eq 0 ] && [ -e "%{_sysconfdir}/regionserverclnt.cfg" ]; then
     %{_sbindir}/registercloudguest --clean
 fi
+# Avoid unpredictable errors in the build service. The build service check
+# that removes packages does not guarantee that the generic config package
+# gets removed during install/remove testing prior to removing the
+# cloud-regionsrv-client package. The generic example configuration
+# triggers errors during the clean operation. Therefore we force the exit
+# code to be 0 during build. If a user installs this package on a system with
+# and invalid config they have to uninstall the package with the "--noscripts"
+# option.
+if [ -e "/.buildenv" ]; then
+    exit 0
+fi
 
 %post
 # Scripts need access to the update infrastructure, do not execute them


### PR DESCRIPTION
During install and removal test in the build service the order of dependent packages is non deterministic, this may lead to failures during build. Force the exit condition of preun to be 0 to avoid this non deterministic failure.