### PR TITLE
Store IP addresses as str

### DIFF
--- a/integration_test-process.txt
+++ b/integration_test-process.txt
@@ -22,6 +22,7 @@ After installing the test package with "zypper in"
   + grep DOCKER_CONFIG /etc/profile.local has value
   + grep susecloud /etc/docker/daemon.json has value
   + grep susecloud /etc/containers/registries.conf has value
+  + instance-flavor-check return PAYG/BYOS accordingly
 - registercloudguest --clean
   + no error no message
   + zypper lr has no repos
@@ -35,6 +36,7 @@ After installing the test package with "zypper in"
     - does not exists or has no reference to susecloud
   + cat /etc/containers/registries.conf
     - does not exists or has no reference to susecloud
+  + instance-flavor-check return BYOS
 - registercloudguest
   + no error
   + success message on stdout
@@ -64,6 +66,7 @@ After installing the test package with "zypper in"
   + systemctl status containerbuild-regionsrv.service
   + podman run --network host -it bci/bci-base
   + zypper lr should have SLES repos
+  + instance-flavor-check return PAYG/BYOS accordingly
 - registercloudguest --clean
   + zypper lr has no repos
   On SLE 15

--- a/lib/cloudregister/registerutils.py
+++ b/lib/cloudregister/registerutils.py
@@ -2449,9 +2449,9 @@ def _get_region_server_ips(cfg=None):
             region_servers_dns.append(srv_id)
             continue
         if isinstance(ip_addr, ipaddress.IPv6Address):
-            region_servers_ipv6.append(ip_addr)
+            region_servers_ipv6.append(format(ip_addr))
         else:
-            region_servers_ipv4.append(ip_addr)
+            region_servers_ipv4.append(format(ip_addr))
 
     return region_servers_ipv4, region_servers_ipv6, region_servers_dns
 

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -23,7 +23,7 @@ import tempfile
 import toml
 import yaml
 from collections import namedtuple
-from ipaddress import IPv4Address, IPv6Address
+from ipaddress import IPv6Address
 from pytest import raises
 from textwrap import dedent
 
@@ -4177,7 +4177,7 @@ def test_has_no_ipv4_ipv6_access(
 
 @patch('cloudregister.registerutils.add_region_server_args_to_URL')
 @patch('cloudregister.registerutils.get_config')
-def test_ger_region_server_ips(
+def test_get_region_server_ips(
     mock_get_config,
     mock_add_region_server_args_to_URL
 ):
@@ -4188,8 +4188,8 @@ def test_ger_region_server_ips(
     mock_get_config.return_value = cfg
     assert utils._get_region_server_ips() == \
         (
-            [IPv4Address('1.1.1.1'), IPv4Address('2.2.2.2')],
-            [IPv6Address('fc11::2')],
+            ['1.1.1.1', '2.2.2.2'],
+            ['fc11::2'],
             ['foo']
         )
 


### PR DESCRIPTION
When getting the IP addresses from the region server, we were storing `IPv4Address` and `IPv6Address` types

When we do the socket connection with that it fails

```
connection = socket.create_connection((server_ip, 443), timeout=2)
  File "/usr/lib64/python3.4/socket.py", line 498, in create_connection
    for res in getaddrinfo(host, port, 0, SOCK_STREAM):
  File "/usr/lib64/python3.4/socket.py", line 537, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
TypeError: getaddrinfo() argument 1 must be string or None
```

This Fixes bsc#1247466