### PR TITLE
Modify the credentials_files_are_equal interface

### DIFF
--- a/cloud-regionsrv-client.changes
+++ b/cloud-regionsrv-client.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
-Fri Aug  8 14:46:13 UTC 2025 - Jesús Bermúdez Velázquez <jesus.bv@suse.com>
+$RELEASE_DATE
 
-- Update version to 10.5.2
+- Update version to NEXT
   + Fix the case where an instance can not get verified
     in any of the siblings, leaving credential files present
     under /etc/zypp/credentials.d

--- a/usr/lib/zypp/plugins/urlresolver/susecloud
+++ b/usr/lib/zypp/plugins/urlresolver/susecloud
@@ -39,10 +39,13 @@ class SUSECloudPlugin(Plugin):
         repo_credentials = headers.get('credentials')
         if zypper_pid != prev_zypper_pid:
             verify_credentials = True
+            zypper_root = utils.get_zypper_target_root()
         # Note this logic breaks when FATE#320882/PM-1251 gets implemented
         if (
                 verify_credentials and not
-                utils.credentials_files_are_equal(repo_credentials)
+                utils.credentials_files_are_equal(
+                    repo_credentials, zypper_root
+                )
         ):
             self.error(
                 {'CREDENTIAL_ERROR': 'INCONSISTENT'},


### PR DESCRIPTION
Make the function less expensive on re-use. Previously the function encapsulated the extraction of the root directory from the zypper command line, meaning for every invocation we ended up calling the ps utility. A use case has arisen where we want to re-use the function to find orphaned credetials. In this case zypper is not running and trying to extract the root path becomes and expensive undertaking. With this change the function takes the rtarget root path as an additional argument, which by default is the system root, i.e. /. This pushed the responsibility of getting the target root to the caller. At this point only the urlresolver needs the target root functionality. Further, the urlresolver already has a feature to reduce the redundant calls when we are in the same zypper process leading to additional efficiency when extracting the target root.

Create 2 new constants to reduce repetition of the base credentials name used as a string and the zypper credentials path.