### PR TITLE
Consist path merge

### DIFF
--- a/integration_test-process.txt
+++ b/integration_test-process.txt
@@ -1,6 +1,6 @@
 Test matrix cloud-regionsrv-client
 
-Test one SLE 15 based and one SLE 12 based instance
+Test one SLE 15, SLE 16 and one SLE 12 based instance
 
 on-demand
 After installing the test package with "zypper in"
@@ -17,12 +17,12 @@ After installing the test package with "zypper in"
   + zypper lr has repos
   + SUSEConnect -s shows the registration status
   + SUSEConnect -l shows a list of modules/extensions available or installed
-  On SLE 15
+  + instance-flavor-check return PAYG/BYOS accordingly
+  On SLE 15 and later
   + grep REGISTRY_AUTH_FILE /etc/profile.local has value
   + grep DOCKER_CONFIG /etc/profile.local has value
   + grep susecloud /etc/docker/daemon.json has value
   + grep susecloud /etc/containers/registries.conf has value
-  + instance-flavor-check return PAYG/BYOS accordingly
 - registercloudguest --clean
   + no error no message
   + zypper lr has no repos
@@ -30,19 +30,20 @@ After installing the test package with "zypper in"
   + ls /etc/zypp/services.d/ returns empty
   + ls /var/cache/cloudregister/*.pkl returns empty or dir does not exist
   + grep susecloud /etc/hosts returns empty
+  + instance-flavor-check return PAYG/BYOS accordingly
+  On SLE 15 and later
   + grep REGISTRY_AUTH_FILE /etc/profile.local returns empty
   + grep DOCKER_CONFIG /etc/profile.local returns empty
   + cat /etc/docker/daemon.json
     - does not exists or has no reference to susecloud
   + cat /etc/containers/registries.conf
     - does not exists or has no reference to susecloud
-  + instance-flavor-check return BYOS
 - registercloudguest
   + no error
   + success message on stdout
   + $? is 0
   + zypper lr has repos
-  On SLE 15
+  On SLE 15 and later
   + cat /etc/docker/daemon.json
     - Should have registry for the update infrastructure and registry.suse.com
   + cat /etc/containers/registries.conf
@@ -65,11 +66,10 @@ After installing the test package with "zypper in"
   + systemctl start containerbuild-regionsrv.service
   + systemctl status containerbuild-regionsrv.service
   + podman run --network host -it bci/bci-base
-  + zypper lr should have SLES repos
-  + instance-flavor-check return PAYG/BYOS accordingly
+  + zypper lr should have SLES repos; exit the container
 - registercloudguest --clean
   + zypper lr has no repos
-  On SLE 15
+  On SLE 15 and later
   + cat /etc/docker/daemon.json
     - File does not exist or
     - No reference to registry on update infrastructure and registry.suse.com
@@ -86,7 +86,7 @@ After installing the test package with "zypper in"
   + success message on stdout
   + $? is 0
   + zypper lr has repos
-  On SLE 15
+  On SLE 15 and later
   + cat /etc/docker/daemon.json
     - Should have registry for the update infrastructure and registry.suse.com
   + cat /etc/containers/registries.conf

--- a/tests/test_registercloudguest.py
+++ b/tests/test_registercloudguest.py
@@ -272,7 +272,10 @@ def test_register_cloud_guest_force_reg_zypper_not_running_region_changed(
          SMTregistryName="registry-ec2.susecloud.net"
          region="antarctica-1"/>''')
 
-    smt_server = SMT(etree.fromstring(smt_data_ipv46))
+    child = etree.fromstring(smt_data_ipv46)
+
+    smt_server = SMT(child)
+
     mock_get_current_smt.return_value = smt_server
     fake_args = SimpleNamespace(
         clean_up=False,
@@ -294,7 +297,7 @@ def test_register_cloud_guest_force_reg_zypper_not_running_region_changed(
     mock_smt_is_responsive.side_effect = [False, True]
     mock_smt_is_equivalent.return_value = False
     mock_get_update_servers.return_value = [smt_server]
-    mock_utils_fetch_smt_data.return_value = [smt_server]
+    mock_utils_fetch_smt_data.return_value = [child]
     with tempfile.TemporaryDirectory(suffix='foo') as tdir:
         mock_get_state_dir.return_value = tdir
     with raises(SystemExit) as sys_exit:

--- a/tests/test_registerutils.py
+++ b/tests/test_registerutils.py
@@ -103,7 +103,7 @@ def test_get_credentials():
 
 def test_get_state_dir():
     state_dir = utils.get_state_dir()
-    assert state_dir == '/var/cache/cloudregister/'
+    assert state_dir == '/var/cache/cloudregister'
 
 
 @patch('cloudregister.registerutils.get_state_dir')


### PR DESCRIPTION
-  update the uses of os.path.join to use either os.sep.join or
    os.path.normpath with os.sep.join to avoid oddities of th path.join
    implementation if the second argument starts with a /. While we have not
    had problems with this so far the previous use of path.join required
    careful setu of constants and processing when files are being used. Also
    discovered 1 incorrect use of path.join() and found another case where
    string concatenation was used.

- Add clarifying note to separate command that should be run on SLE 15 or later
    and commands that only apply to SLE 12. Also clean up after changes introduced
    with 1faefb5e66
