### PR TITLE
Drop obsolete switchcloudguestservices.py take two

### DIFF
--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -856,4 +856,3 @@ def main(args):
 def app():  # pragma: no cover
     args = argparse.parse_args()
     main(args)
-    utils.switch_services_to_plugin()

--- a/cloudregister/registerutils.py
+++ b/cloudregister/registerutils.py
@@ -2125,58 +2125,6 @@ def set_registration_completed_flag():
 
 
 # ----------------------------------------------------------------------------
-def switch_services_to_plugin():
-    """Switches a .service based RIS service that points to the update
-       infrastructure to the service plugin"""
-    service_plugin = '/usr/sbin/cloudguest-repo-service'
-    service_plugin_loc = '/usr/lib/zypp/plugins/services'
-    service_files = glob.glob('/etc/zypp/services.d/*.service')
-    update_servers = get_available_smt_servers()
-    # If we have no available servers there is a risk that we would break
-    # the user setup if additional services that do not point to the update
-    # infrastructure exists, thus do nothing
-    if not update_servers:
-        return
-    service_targets = []
-    for update_server in update_servers:
-        service_targets.append(update_server.get_ipv4())
-        service_targets.append(update_server.get_ipv6())
-        service_targets.append(update_server.get_FQDN())
-
-    for service_file in service_files:
-        link_created = None
-        cfg = configparser.RawConfigParser()
-        try:
-            cfg.read(service_file)
-        except configparser.Error:
-            log.warning('Unable to parse "%s" skipping' % service_file)
-            continue
-        # This implementation depends on each config file having all sections
-        # point to the same service target. If this is not the case and one
-        # of the sections points to a target we recognize then the other
-        # service will be dropped
-        for section in cfg.sections():
-            url = cfg.get(section, 'url')
-            if url and not url.startswith('plugin:'):
-                for service_target in service_targets:
-                    if (
-                            url.startswith('http://%s' % service_target) or
-                            url.startswith('https://%s' % service_target)
-                    ):
-                        link_dest = os.path.normpath(
-                            os.sep.join([service_plugin_loc, section])
-                        )
-                        # Assume /usr/sbin and /usr/lib/zypp/plugins are on the
-                        # same filesystem
-                        if os.path.exists(link_dest):
-                            os.unlink(link_dest)
-                        os.symlink(service_plugin, link_dest)
-                        link_created = 1
-        if link_created:
-            os.unlink(service_file)
-
-
-# ----------------------------------------------------------------------------
 def get_domain_name_from_region_server():
     cfg = get_config()
     region_rmt_server_data = fetch_smt_data(cfg, None)

--- a/test/unit/registerutils_test.py
+++ b/test/unit/registerutils_test.py
@@ -2845,68 +2845,6 @@ class TestRegisterUtils:
         utils._set_state_file('foo')
         mock_path.assert_called_once_with('foo')
 
-    @patch('cloudregister.registerutils.get_available_smt_servers')
-    def test_switch_services_to_plugin_no_servers(self, mock_get_available_smt_servers):
-        mock_get_available_smt_servers.return_value = []
-        assert utils.switch_services_to_plugin() is None
-
-    @patch('cloudregister.registerutils.configparser.RawConfigParser.read')
-    @patch('cloudregister.registerutils.glob.glob')
-    @patch('cloudregister.registerutils.get_available_smt_servers')
-    def test_switch_services_to_plugin_config_parse_error(
-        self,
-        mock_get_available_smt_servers,
-        mock_glob,
-        mock_raw_config_parser_read
-    ):
-        smt_data_ipv46 = dedent('''\
-            <smtInfo fingerprint="00:11:22:33"
-             SMTserverIP="192.168.1.1"
-             SMTserverIPv6="fc00::1"
-             SMTserverName="smt-foo.susecloud.net"
-             SMTregistryName="registry-foo.susecloud.net"
-             region="antarctica-1"/>''')
-        smt_server = SMT(etree.fromstring(smt_data_ipv46))
-        mock_get_available_smt_servers.return_value = [smt_server]
-        mock_glob.return_value = ['foo']
-        mock_raw_config_parser_read.side_effect = configparser.Error('foo')
-        utils.switch_services_to_plugin()
-        assert 'Unable to parse "foo" skipping' in self._caplog.text
-
-    @patch('cloudregister.registerutils.os.path.exists')
-    @patch('cloudregister.registerutils.os.unlink')
-    @patch('cloudregister.registerutils.os.symlink')
-    @patch('cloudregister.registerutils.glob.glob')
-    @patch('cloudregister.registerutils.get_available_smt_servers')
-    def test_switch_services_to_plugin_unlink_service(
-        self,
-        mock_get_available_smt_servers,
-        mock_glob,
-        mock_os_symlink,
-        mock_os_unlink,
-        mock_os_path_exists
-    ):
-        smt_data_ipv46 = dedent('''\
-            <smtInfo fingerprint="00:11:22:33"
-             SMTserverIP="192.168.1.1"
-             SMTserverIPv6="fc00::1"
-             SMTserverName="smt-foo.susecloud.net"
-             SMTregistryName="registry-foo.susecloud.net"
-             region="antarctica-1"/>''')
-        smt_server = SMT(etree.fromstring(smt_data_ipv46))
-        mock_get_available_smt_servers.return_value = [smt_server]
-        mock_glob.return_value = ['../data/service.service']
-        mock_os_path_exists.return_value = True
-        utils.switch_services_to_plugin()
-        mock_os_symlink.assert_called_once_with(
-            '/usr/sbin/cloudguest-repo-service',
-            '/usr/lib/zypp/plugins/services/Public_Cloud_Module_x86_64'
-        )
-        assert mock_os_unlink.call_args_list == [
-            call('/usr/lib/zypp/plugins/services/Public_Cloud_Module_x86_64'),
-            call('../data/service.service')
-        ]
-
     @patch('cloudregister.registerutils.fetch_smt_data')
     @patch('cloudregister.registerutils.get_config')
     def test_get_domain_name_from_region_server(


### PR DESCRIPTION
Another version in code to handle the transition from http based repo urls to resolver based urls was found and can be dropped because the transition period is over. This Fixes #185 and is related to bsc#1245370