### PR TITLE
Refactor cleanup code

### DIFF
--- a/cloudregister/cloudguest_lic_watcher.py
+++ b/cloudregister/cloudguest_lic_watcher.py
@@ -55,7 +55,7 @@ def maybe_drop_registration(license_type):
         if not utils.uses_rmt_as_scc_proxy():
             log.info(
                 'Detected flavor change to BYOS, clean up registration')
-            utils.clean_all()
+            utils.clean_all_legacy()
             utils.exec_subprocess(['systemctl', 'disable', SERVICE_NAME])
 
 
@@ -72,7 +72,7 @@ def maybe_register_system(license_type):
             # The system is registered to the update infrastructure using
             # a registration code. Now that the system is PAYG we have to
             # clean up that registration
-            utils.clean_all()
+            utils.clean_all_legacy()
             log.info(base_msg.format(
                 status='removed registration to update infra as BYOS')
             )
@@ -80,7 +80,7 @@ def maybe_register_system(license_type):
         if not current_target and utils.is_scc_connected():
             # The system is registered to the SUSE Customer center. Now
             # that the system is PAYG we have to clean up that registration
-            utils.clean_all()
+            utils.clean_all_legacy()
             log.info(base_msg.format(
                 status='removed registration to SCC as BYOS')
             )

--- a/cloudregister/cloudguest_repo_service.py
+++ b/cloudregister/cloudguest_repo_service.py
@@ -24,7 +24,10 @@ from lxml import etree
 from requests.auth import HTTPBasicAuth
 
 from cloudregister.logger import Logger
-from cloudregister.defaults import LOG_FILE
+from cloudregister.defaults import (
+    LOG_FILE,
+    REGISTRATION_DATA_DIR
+)
 import cloudregister.registerutils as utils
 
 log_instance = Logger()
@@ -34,7 +37,7 @@ log = Logger.get_logger()
 
 def print_repo_data(update_server, activation, available_repos):
     """Print repository data from product activation info."""
-    service_revert_file = os.path.join(utils.REGISTRATION_DATA_DIR, 'installservice')
+    service_revert_file = os.path.join(REGISTRATION_DATA_DIR, 'installservice')
     service_info = activation.get('service')
     service_name = service_info.get('name')
     service_url = service_info.get('url')

--- a/cloudregister/createregioninfo.py
+++ b/cloudregister/createregioninfo.py
@@ -22,11 +22,14 @@ import os
 import sys
 
 import cloudregister.registerutils as utils
+from cloudregister.defaults import (
+    FRAMEWORK_IDENTIFIER
+)
 
 
 def app():
     region_info_path = os.path.join(
-        utils.get_state_dir(), utils.FRAMEWORK_IDENTIFIER
+        utils.get_state_dir(), FRAMEWORK_IDENTIFIER
     )
 
     if os.path.exists(region_info_path):

--- a/cloudregister/defaults.py
+++ b/cloudregister/defaults.py
@@ -13,4 +13,29 @@
 #
 #
 LOG_FILE = '/var/log/cloudregister'
+
+# etc content
 ZYPP_SERVICES = '/etc/zypp/services.d'
+HOSTSFILE_PATH = '/etc/hosts'
+REGISTRY_CREDENTIALS_PATH = '/etc/containers/config.json'
+PROFILE_LOCAL_PATH = '/etc/profile.local'
+REGISTRIES_CONF_PATH = '/etc/containers/registries.conf'
+DOCKER_CONFIG_PATH = '/etc/docker/daemon.json'
+SUMA_REGISTRY_CONF_PATH = '/etc/uyuni/uyuni-tools.yaml'
+BASE_PRODUCT_PATH = '/etc/products.d/baseproduct'
+ZYPP_CREDENTIALS_PATH = '/etc/zypp/credentials.d'
+
+# var content
+OLD_REGISTRATION_DATA_DIR = '/var/lib/cloudregister'
+REGISTRATION_DATA_DIR = '/var/cache/cloudregister'
+
+# constants
+AVAILABLE_SMT_SERVER_DATA_FILE_NAME = 'availableSMTInfo_%s.obj'
+BASE_CREDENTIALS_NAME = 'SCCcredentials'
+FRAMEWORK_IDENTIFIER = 'framework_info'
+NEW_REGISTRATION_MARKER = 'newregistration'
+REGISTRATION_COMPLETED_MARKER = 'registrationcompleted'
+REGISTERED_SMT_SERVER_DATA_FILE_NAME = 'currentSMTInfo.obj'
+RMT_AS_SCC_PROXY_MARKER = 'rmt_is_scc_proxy'
+SUSE_REGISTRY = 'registry.suse.com'
+REGSHARING_SYNC_TIME = 30

--- a/cloudregister/exceptions.py
+++ b/cloudregister/exceptions.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025, SUSE LLC, All rights reserved.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+
+
+class CloudRegister(Exception):
+    """
+    Case class for CloudRegister exceptions
+    """
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return format(self.message)
+
+
+class CloudRegisterPathError(CloudRegister):
+    """
+    Exception raised if a Path operation e.g mkdir failed
+    """
+
+
+class CloudRegisterScopeError(CloudRegister):
+    """
+    Exception raised if a managed file is outside the git scope
+    """
+
+
+class CloudRegisterGitError(CloudRegister):
+    """
+    Exceptin raised if a git operation failed
+    """

--- a/cloudregister/git.py
+++ b/cloudregister/git.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2025, SUSE LLC, All rights reserved.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+import os
+from pathlib import Path
+from collections import namedtuple
+
+from cloudregister.logger import Logger
+from cloudregister.registerutils import (
+    exec_subprocess,
+    get_state_dir,
+    clean_all_legacy
+)
+from cloudregister.defaults import (
+    REGISTERED_SMT_SERVER_DATA_FILE_NAME
+)
+from cloudregister.exceptions import (
+    CloudRegisterPathError,
+    CloudRegisterScopeError,
+    CloudRegisterGitError
+)
+
+log = Logger.get_logger()
+
+managed_file_type = namedtuple(
+    'managed_file_type', ['new', 'done']
+)
+
+
+class Git:
+    """
+    Use git for content management of data changed by cloudregister
+    """
+    def __init__(self, directory):
+        self.managed_dir = directory
+        self.managed_dir_git = '{}/.git'.format(directory)
+        self.managed_files = {}
+        registration_smt_cache_file_name = os.path.normpath(
+            os.sep.join(
+                [get_state_dir(), REGISTERED_SMT_SERVER_DATA_FILE_NAME]
+            )
+        )
+        self.git_cmd = [
+            'git',
+            '--work-tree', self.managed_dir,
+            '--git-dir', self.managed_dir_git
+        ]
+        if not os.path.isdir(self.managed_dir_git) and \
+           os.path.isfile(registration_smt_cache_file_name):
+            # The system is already registered but is not using the
+            # git content manager. The origin state is therefore
+            # dirty and needs to be cleaned up first with the
+            # legacy cleanup code. From there the new git based
+            # content management can be established.
+            clean_all_legacy()
+
+        try:
+            if not os.path.isdir(self.managed_dir_git):
+                exec_subprocess(['git', 'init', self.managed_dir])
+                exec_subprocess(
+                    self.git_cmd + ['config', 'user.email', 'public-cloud-dev@susecloud.net']
+                )
+                exec_subprocess(
+                    self.git_cmd + ['config', 'user.name', 'Public Cloud Team']
+                )
+        except Exception as issue:
+            raise CloudRegisterGitError(
+                'Cannot init git at: {}: {}'.format(
+                    self.managed_dir, issue
+                )
+            )
+
+    def __enter__(self):
+        return self
+
+    def manage(self, filename):
+        if not self._is_managed(filename):
+            if not os.path.exists(filename):
+                self._manage_new(filename)
+            else:
+                self._manage_existing(filename)
+
+    def done(self, lookup_filename=None):
+        """
+        Mark file as being fully processed, this excludes it from
+        the cleanup phase until explicitly requested via cleanup().
+        If no lookup_filename is given, all files known to the
+        instance will be marked as done
+        """
+        for filename, managed in self.managed_files.items():
+            if filename and lookup_filename != filename:
+                next
+            self.managed_files[filename] = managed_file_type(
+                new=managed.new, done=True
+            )
+
+    def is_empty(self, filename):
+        """
+        Check if file is empty. If file does not exist it's also empty
+        """
+        if os.path.exists(filename):
+            return not bool(Path(filename).stat().st_size)
+        return True
+
+    def cleanup(self):
+        """
+        Checkout all origin versions from managed directory
+        Please note; Files created as net new files from us
+        will stay as empty files in the system
+        """
+        stdout, stderr, failed = exec_subprocess(
+            self.git_cmd + ['ls-files', '-m']
+        )
+        if not failed:
+            for modified in stdout.decode().split(os.linesep):
+                if modified:
+                    filename = '{}/{}'.format(self.managed_dir, modified)
+                    log.info('Restore file: {}'.format(filename))
+                    stdout, stderr, failed = exec_subprocess(
+                        self.git_cmd + ['checkout', filename]
+                    )
+                    if self.is_empty(filename):
+                        log.info('Deleting empty file: {}'.format(filename))
+                        Path(filename).unlink()
+        if failed:
+            log.error('Could not checkout origin: {}:{}'.format(
+                stdout, stderr)
+            )
+
+    def _is_managed(self, filename):
+        if not filename.startswith(self.managed_dir):
+            raise CloudRegisterScopeError(
+                'Given filename {} is outside git scope dir: {}'.format(
+                    filename, self.managed_dir
+                )
+            )
+        if self.managed_files.get(filename):
+            return True
+        return False
+
+    def _manage_new(self, filename):
+        """
+        Commit a net new file as empty version to the git
+        """
+        log.info('Manage new file: {}'.format(filename))
+        self.managed_files[filename] = managed_file_type(
+            new=True, done=False
+        )
+        try:
+            with open(filename, 'w'):
+                pass
+        except Exception as issue:
+            raise CloudRegisterPathError(
+                'Failed to create new file: {}'.format(issue)
+            )
+        stdout, stderr, failed = exec_subprocess(
+            self.git_cmd + ['add', filename]
+        )
+        if not failed:
+            stdout, stderr, failed = exec_subprocess(
+                self.git_cmd + [
+                    'commit', '--allow-empty', '-m',
+                    'origin:{}'.format(filename)
+                ]
+            )
+        if failed:
+            raise CloudRegisterGitError(
+                'Failed to add managed file to git: {}:{}'.format(
+                    stdout, stderr
+                )
+            )
+
+    def _manage_existing(self, filename):
+        """
+        Commit an existing file as origin version to the git once
+        such that it can be restored
+        """
+        log.info('Manage existing file: {}'.format(filename))
+        self.managed_files[filename] = managed_file_type(
+            new=False, done=False
+        )
+        if self._known_to_git(filename):
+            log.info('File {} already managed'.format(filename))
+            return
+        stdout, stderr, failed = exec_subprocess(
+            self.git_cmd + ['add', filename]
+        )
+        if not failed:
+            stdout, stderr, failed = exec_subprocess(
+                self.git_cmd + ['commit', '-m', 'origin:{}'.format(filename)]
+            )
+        if failed:
+            raise CloudRegisterGitError(
+                'Failed to add managed file to git: {}:{}'.format(
+                    stdout, stderr
+                )
+            )
+
+    def _known_to_git(self, filename):
+        _, _, failed = exec_subprocess(
+            self.git_cmd + ['ls-files', '--error-unmatch', filename]
+        )
+        if not failed:
+            return True
+        return False
+
+    def _cleanup(self):
+        """
+        Cleanup all unfinished files
+        """
+        for filename, managed in self.managed_files.items():
+            if not managed.done:
+                log.info('Cleaning up unfinished file: {}'.format(filename))
+                stdout, stderr, failed = exec_subprocess(
+                    self.git_cmd + ['checkout', filename]
+                )
+                if self.is_empty(filename):
+                    log.info('Deleting empty file: {}'.format(filename))
+                    Path(filename).unlink()
+                if failed:
+                    log.error('Could not checkout origin {}: {}:{}'.format(
+                        filename, stdout, stderr)
+                    )
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self._cleanup()

--- a/cloudregister/registerutils.py
+++ b/cloudregister/registerutils.py
@@ -40,31 +40,50 @@ from requests.auth import HTTPBasicAuth
 from cloudregister.logger import Logger
 from cloudregister import smt
 
-AVAILABLE_SMT_SERVER_DATA_FILE_NAME = 'availableSMTInfo_%s.obj'
-BASE_CREDENTIALS_NAME = 'SCCcredentials'
-FRAMEWORK_IDENTIFIER = 'framework_info'
-HOSTSFILE_PATH = '/etc/hosts'
-NEW_REGISTRATION_MARKER = 'newregistration'
-REGISTRATION_COMPLETED_MARKER = 'registrationcompleted'
-OLD_REGISTRATION_DATA_DIR = '/var/lib/cloudregister'
-REGISTRATION_DATA_DIR = '/var/cache/cloudregister'
-REGISTERED_SMT_SERVER_DATA_FILE_NAME = 'currentSMTInfo.obj'
-RMT_AS_SCC_PROXY_MARKER = 'rmt_is_scc_proxy'
-REGISTRY_CREDENTIALS_PATH = '/etc/containers/config.json'
-PROFILE_LOCAL_PATH = '/etc/profile.local'
-REGISTRIES_CONF_PATH = '/etc/containers/registries.conf'
-DOCKER_CONFIG_PATH = '/etc/docker/daemon.json'
-SUMA_REGISTRY_CONF_PATH = '/etc/uyuni/uyuni-tools.yaml'
-BASE_PRODUCT_PATH = '/etc/products.d/baseproduct'
-SUSE_REGISTRY = 'registry.suse.com'
-REGSHARING_SYNC_TIME = 30
-ZYPP_CREDENTIALS_PATH = '/etc/zypp/credentials.d'
+from cloudregister.defaults import (
+    AVAILABLE_SMT_SERVER_DATA_FILE_NAME,
+    BASE_CREDENTIALS_NAME,
+    FRAMEWORK_IDENTIFIER,
+    HOSTSFILE_PATH,
+    NEW_REGISTRATION_MARKER,
+    REGISTRATION_COMPLETED_MARKER,
+    REGISTRATION_DATA_DIR,
+    REGISTERED_SMT_SERVER_DATA_FILE_NAME,
+    RMT_AS_SCC_PROXY_MARKER,
+    REGISTRY_CREDENTIALS_PATH,
+    PROFILE_LOCAL_PATH,
+    REGISTRIES_CONF_PATH,
+    DOCKER_CONFIG_PATH,
+    SUMA_REGISTRY_CONF_PATH,
+    BASE_PRODUCT_PATH,
+    SUSE_REGISTRY,
+    REGSHARING_SYNC_TIME,
+    ZYPP_CREDENTIALS_PATH
+)
 
 requests.packages.urllib3.disable_warnings(
     requests.packages.urllib3.exceptions.InsecureRequestWarning
 )
 
 log = Logger.get_logger()
+
+etc_content = None
+
+
+# ----------------------------------------------------------------------------
+def etc_manage(filename, as_empty_file=False):
+    """
+    Add file to etc content manager if defined
+
+    if as_empty_file is set to True the given file will
+    be added as an empty file to the content manager
+    """
+    if etc_content:
+        if as_empty_file:
+            os.rename(filename, '{}.new'.format(filename))
+        etc_content.manage(filename)
+        if as_empty_file:
+            os.rename('{}.new'.format(filename), filename)
 
 
 # ----------------------------------------------------------------------------
@@ -87,6 +106,7 @@ def add_hosts_entry(smt_server):
             smt_server.get_registry_FQDN()
         )
 
+    etc_manage('/etc/hosts')
     with open('/etc/hosts', 'a') as hosts_file:
         hosts_file.write(smt_hosts_entry_comment)
         hosts_file.write(entry)
@@ -112,20 +132,39 @@ def add_region_server_args_to_URL(api, cfg):
 
 
 # ----------------------------------------------------------------------------
-def clean_all():
-    """Clean up any registration artifacts"""
-    try:
-        clean_non_free_extensions()
-    except Exception as err:
-        log.info('Could not check the system product data: {}'.format(err))
+def clean_all_legacy():
+    """
+    Clean up any registration artifacts
 
+    This is a legacy method which cleans up registration data
+    without using the git content manager. This function is kept
+    for tools not yet moved to use git and to allow transition
+    from non git based content management to git based content
+    management, e.g on package update of cloud-regionsrv-client
+    on already registered clients.
+    """
+    # Clean registrations via API requests
+    deregister_non_free_extensions()
+    deregister_from_update_infrastructure()
+    deregister_from_SCC()
+
+    # Clean all data from etc
+    clean_repo_artifacts()
     clean_registry_setup()
-    remove_registration_data()
+    clean_hosts_file()
+
+    # Clean all cache data from /var/cache
+    clean_cache()
+
+
+# ----------------------------------------------------------------------------
+def clean_cache():
     clean_smt_cache()
+    clear_rmt_as_scc_proxy_flag()
     clear_new_registration_flag()
     clean_framework_identifier()
-    clean_hosts_file()
     clear_registration_completed_flag()
+    clean_registered_smt_data_file()
 
 
 # ----------------------------------------------------------------------------
@@ -162,9 +201,34 @@ def clean_hosts_file(domain_name=None):
     except IndexError:
         pass
 
+    etc_manage(HOSTSFILE_PATH)
     with open(HOSTSFILE_PATH, 'wb') as hosts_file:
         for entry in new_hosts_content:
             hosts_file.write(entry)
+
+
+# ----------------------------------------------------------------------------
+def clean_repo_artifacts():
+    """Remove the artifacts related to repository handling for a registration
+    """
+    repo_server_names = []
+    # Lookup SCC connected...
+    if is_scc_connected():
+        repo_server_names.append('suse.com')
+
+    # Lookup update infrastructure connected...
+    smt_data_file = _get_registered_smt_file_path()
+    if os.path.exists(smt_data_file):
+        smt = get_smt_from_store(smt_data_file)
+        repo_server_names.append(smt.get_FQDN())
+
+    if repo_server_names:
+        _remove_credentials(repo_server_names)
+        _remove_repos(repo_server_names)
+        _remove_service(repo_server_names)
+
+    if os.path.exists('/etc/SUSEConnect'):
+        os.unlink('/etc/SUSEConnect')
 
 
 # ----------------------------------------------------------------------------
@@ -173,6 +237,14 @@ def clean_framework_identifier():
     framework_file_path = os.sep.join([get_state_dir(), FRAMEWORK_IDENTIFIER])
     if os.path.exists(framework_file_path):
         os.unlink(framework_file_path)
+
+
+# ----------------------------------------------------------------------------
+def clean_registered_smt_data_file():
+    """Remove the registered SMT data cache file"""
+    smt_data_file = _get_registered_smt_file_path()
+    if os.path.exists(smt_data_file):
+        os.unlink(smt_data_file)
 
 
 # ----------------------------------------------------------------------------
@@ -211,35 +283,39 @@ def is_product_removable(triplet):
 
 
 # ----------------------------------------------------------------------------
-def clean_non_free_extensions():
-    """Remove/uninstall non free extensions from the system."""
-    extensions = get_extensions()
-    installed_products = get_installed_products()
+def deregister_non_free_extensions():
+    """deregister non free extensions from the system."""
+    try:
+        extensions = get_extensions()
+        installed_products = get_installed_products()
 
-    for extension in extensions:
-        # The following not free condition checks on
-        # the access capability of the extension
-        # This is a server side capability
-        if not extension.get('free', True):
-            triplet = get_product_triplet(extension)
-            triplet = '{name}/{version}/{arch}'.format(
-                name=triplet.name,
-                version=triplet.version,
-                arch=triplet.arch
-            )
-            if triplet in installed_products and is_product_removable(triplet):
-                reg_prod = register_product(
-                    registration_target=get_current_smt(),
-                    product=triplet,
-                    de_register=True
+        for extension in extensions:
+            # The following not free condition checks on
+            # the access capability of the extension
+            # This is a server side capability
+            if not extension.get('free', True):
+                triplet = get_product_triplet(extension)
+                triplet = '{name}/{version}/{arch}'.format(
+                    name=triplet.name,
+                    version=triplet.version,
+                    arch=triplet.arch
                 )
-                msg = 'Non free extension {} '.format(triplet)
-                if reg_prod.returncode:
-                    msg += 'failed to be removed'
-                else:
-                    msg += 'removed'
-
-                log.info(msg)
+                if triplet in installed_products and is_product_removable(triplet):
+                    reg_prod = register_product(
+                        registration_target=get_current_smt(),
+                        product=triplet,
+                        de_register=True
+                    )
+                    msg = 'Non free extension {} '.format(triplet)
+                    if reg_prod.returncode:
+                        msg += 'failed to be removed'
+                    else:
+                        msg += 'removed'
+                    log.info(msg)
+    except Exception as issue:
+        log.info(
+            'Deregister non free extensions failed with: {}'.format(issue)
+        )
 
 
 # ----------------------------------------------------------------------------
@@ -462,10 +538,38 @@ def register_product(
         log_information = log_information.replace(regcode, 'XXXX')
 
     log.info('Registration: {0}'.format(log_information))
+    etc_manage('{}/{}'.format(ZYPP_CREDENTIALS_PATH, BASE_CREDENTIALS_NAME))
+
+    # get list of zypp setup files eventually existing prior
+    # registration. Those files will not be taken into account
+    # for the registration client.
+    exclude_zypp_files = []
+    for exclude in glob.glob(
+        '/etc/zypp/repos.d/*.repo'
+    ) + glob.glob(
+        '/etc/zypp/services.d/*.service'
+    ) + glob.glob('/etc/zypp/credentials.d/*'):
+        exclude_zypp_files.append(exclude)
+
+    # perform registration
     output, error, returncode = exec_subprocess(cmd, tolog=False)
     suseconnect_type = namedtuple(
         'suseconnect_type', ['returncode', 'output', 'error']
     )
+    # SUSEConnect created new setup files which it does not delete
+    # on deregistration. Let's add these files to the content manager
+    # such that we can handle them properly during cleanup
+    for repo in glob.glob('/etc/zypp/repos.d/*.repo'):
+        if repo not in exclude_zypp_files:
+            etc_manage(repo, as_empty_file=True)
+    for service in glob.glob('/etc/zypp/services.d/*.service'):
+        if service not in exclude_zypp_files:
+            etc_manage(service, as_empty_file=True)
+    for credential in glob.glob('/etc/zypp/credentials.d/*'):
+        if BASE_CREDENTIALS_NAME not in credential and \
+         credential not in exclude_zypp_files:
+            etc_manage(credential, as_empty_file=True)
+
     return suseconnect_type(
         returncode=returncode,
         output=output.decode(),
@@ -837,6 +941,7 @@ def get_registry_credentials(set_new):
 # ----------------------------------------------------------------------------
 def write_registry_credentials(content, set_new):
     """Update the registry credentials file with the value of 'content'."""
+    etc_manage(REGISTRY_CREDENTIALS_PATH)
     try:
         with open(REGISTRY_CREDENTIALS_PATH, 'w') as cred_json_file:
             json.dump(content, cred_json_file)
@@ -945,6 +1050,7 @@ def get_registry_conf_file(container_path, container):
 def update_bashrc(content, mode):
     """Update the env vars for the container engines
     with the location of the config file to the bashrc local file."""
+    etc_manage(PROFILE_LOCAL_PATH)
     try:
         with open(PROFILE_LOCAL_PATH, mode) as bashrc_file:
             bashrc_file.write(content)
@@ -1229,6 +1335,7 @@ def clean_registries_conf_docker(private_registry_fqdn):
 # ----------------------------------------------------------------------------
 def write_registries_conf(registries_conf, container_path, container_name):
     """Write registries_conf content to container_path."""
+    etc_manage(container_path)
     try:
         if container_name == 'podman':
             with open(container_path, 'w') as registries_conf_file:
@@ -1860,7 +1967,7 @@ def https_only(config):
 def import_smtcert_12(smt):
     """Import the SMT certificate on SLES 12"""
     key_chain = '/etc/pki/trust/anchors'
-    if not smt.write_cert(key_chain):
+    if not smt.write_cert(key_chain, etc_content):
         return 0
     if not update_ca_chain(['update-ca-certificates']):
         return 0
@@ -2140,9 +2247,10 @@ def get_domain_name_from_region_server():
 
 
 # ----------------------------------------------------------------------------
-def remove_registration_data():
-    """Reset the instance to an unregistered state"""
-    clear_rmt_as_scc_proxy_flag()
+def deregister_from_update_infrastructure():
+    """
+    Send delete request to registration server
+    """
     smt_data_file = _get_registered_smt_file_path()
     user, password = get_credentials(
         os.sep.join([ZYPP_CREDENTIALS_PATH, BASE_CREDENTIALS_NAME])
@@ -2151,8 +2259,6 @@ def remove_registration_data():
         if not is_new_registration():
             log.info('No credentials, nothing to do server side')
         return
-
-    server_names = []
     auth_creds = HTTPBasicAuth(user, password)
     if os.path.exists(smt_data_file):
         smt = get_smt_from_store(smt_data_file)
@@ -2168,15 +2274,25 @@ def remove_registration_data():
                     'System successfully removed from update infrastructure'
                 )
             else:
-                rmt_check_msg = 'System unknown to update infrastructure, '
-                rmt_check_msg += 'continue with local changes'
+                rmt_check_msg = 'System unknown to update infrastructure'
                 log.info(rmt_check_msg)
-        except requests.exceptions.RequestException as e:
-            log.warning('Unable to remove client registration from server')
-            log.warning(e)
-            log.info('Continue with local artifact removal')
-        server_names.append(server_name)
-        os.unlink(smt_data_file)
+        except requests.exceptions.RequestException as issue:
+            log.warning(
+                'Unable to remove client registration from server: {}'.format(issue)
+            )
+        return server_name
+
+
+# ----------------------------------------------------------------------------
+def deregister_from_SCC():
+    user, password = get_credentials(
+        os.sep.join([ZYPP_CREDENTIALS_PATH, BASE_CREDENTIALS_NAME])
+    )
+    if not user:
+        if not is_new_registration():
+            log.info('No credentials, nothing to do server side')
+        return
+    auth_creds = HTTPBasicAuth(user, password)
     if is_scc_connected():
         log.info('Removing system from SCC')
         try:
@@ -2192,7 +2308,7 @@ def remove_registration_data():
                 scc_check_msg += 'System user name: "%s". '
                 scc_check_msg += 'Local registration artifacts removed.'
                 log.info(scc_check_msg % user)
-        except requests.exceptions.RequestException as e:
+        except requests.exceptions.RequestException as issue:
             scc_except_msg = 'Unable to remove client registration from SCC. '
             scc_except_msg += 'The system is most likely still tracked against'
             scc_except_msg += ' your subscription. Please inform your SCC '
@@ -2200,14 +2316,8 @@ def remove_registration_data():
             scc_except_msg += 'should be removed from SCC. Registration '
             scc_except_msg += 'artifacts removed locally.'
             log.error(scc_except_msg % user)
-            log.warning(e)
-
-        server_names.append('suse.com')
-    else:
-        log.info('No current registration server set.')
-
-    log.info('Removing repository artifacts')
-    _remove_repo_artifacts(server_names)
+            log.warning(issue)
+        return 'suse.com'
 
 
 # ----------------------------------------------------------------------------
@@ -2577,18 +2687,6 @@ def _remove_credentials(smt_server_names):
 
 
 # ----------------------------------------------------------------------------
-def _remove_repo_artifacts(repo_server_names):
-    """Remove the artifacts related to repository handling for a registration
-    """
-    _remove_credentials(repo_server_names)
-    _remove_repos(repo_server_names)
-    _remove_service(repo_server_names)
-
-    if os.path.exists('/etc/SUSEConnect'):
-        os.unlink('/etc/SUSEConnect')
-
-
-# ----------------------------------------------------------------------------
 def _remove_repos(smt_server_names):
     """Remove the repositories for the given server"""
     repo_files = glob.glob('/etc/zypp/repos.d/*')
@@ -2663,6 +2761,7 @@ def _replace_url_target(config_files, new_smt):
         with open(config_file, 'r') as cfg_file:
             content = cfg_file.read()
         if current_service_server in content:
+            etc_manage(config_file)
             with open(config_file, 'w') as new_config:
                 new_config.write(content.replace(
                     current_service_server,
@@ -2827,6 +2926,7 @@ def _set_state_file(filepath):
 # ----------------------------------------------------------------------------
 def _write_suma_conf(updated_content):
     """Update the SUMA SUMA_REGISTRY_CONF_PATH file with the new content."""
+    etc_manage(SUMA_REGISTRY_CONF_PATH)
     try:
         with open(SUMA_REGISTRY_CONF_PATH, 'w') as suma_config:
             yaml.dump(updated_content, suma_config, default_flow_style=False)

--- a/cloudregister/smt.py
+++ b/cloudregister/smt.py
@@ -199,7 +199,7 @@ class SMT:
         self._protocol = protocol
 
     # --------------------------------------------------------------------
-    def write_cert(self, target_dir):
+    def write_cert(self, target_dir, etc_content=None):
         """Write the certificate to the given directory"""
         logging.info('Writing SMT rootCA: %s' % target_dir)
         cert = self.get_cert()
@@ -219,6 +219,8 @@ class SMT:
         # we write here with the known pattern.
         for cert_name in certs_to_write:
             try:
+                if etc_content:
+                    etc_content.manage(ca_file_path % cert_name)
                 with open(ca_file_path % cert_name, 'w') as smt_ca_file:
                     smt_ca_file.write(cert)
             except IOError:

--- a/cloudregister/updatesmtcache.py
+++ b/cloudregister/updatesmtcache.py
@@ -19,12 +19,16 @@ import glob
 import os
 
 import cloudregister.registerutils as utils
+from cloudregister.defaults import (
+    OLD_REGISTRATION_DATA_DIR,
+    REGISTRATION_DATA_DIR
+)
 
 from cloudregister import smt
 
 
 def app():
-    if os.path.exists(utils.OLD_REGISTRATION_DATA_DIR):
+    if os.path.exists(OLD_REGISTRATION_DATA_DIR):
         # The case where both new and old location exist cannot happen. This
         # code runs on package update and as such moves the directory.
         #
@@ -32,14 +36,14 @@ def app():
         # split(). We want to make sure we do not create nested dirs.
         os.system(
             'mv {} {}'.format(
-                utils.OLD_REGISTRATION_DATA_DIR,
-                os.sep.join(utils.REGISTRATION_DATA_DIR.split(os.sep)[:-2])
+                OLD_REGISTRATION_DATA_DIR,
+                os.sep.join(REGISTRATION_DATA_DIR.split(os.sep)[:-2])
             )
         )
 
     # Update the server cache with region information introduced in
     # region server 8.1.3
-    cached_server_files = glob.glob('%s/*SMT*' % utils.REGISTRATION_DATA_DIR)
+    cached_server_files = glob.glob('%s/*SMT*' % REGISTRATION_DATA_DIR)
     proxies = None
     if utils.set_proxy():
         proxies = {

--- a/doc/man/man1/registercloudguest.1
+++ b/doc/man/man1/registercloudguest.1
@@ -51,6 +51,18 @@ removed from SCC.
 Delay the process by the given number of seconds.
 .IP "--debug"
 Debug mode, increase verbosity of logfile information.
+.IP "--git"
+Use git for content management. In this mode a git repo is initialized
+for the /etc directory of the system. All files modified and/or produced
+by the registration client will be managed via the git content manager
+and the registration process runs in a context manager to allow for
+seamless cleanup in case of errors. As files are known to git in this
+mode, also the user initiated cleanup or force registration will make
+use of the content manager to restore data to is origin state. As a
+user there is also the opportunity to watch the changes done by the
+registration client via the git utility. As we can't force git to
+become part of the system, this mode is fully optional and requires
+the installation of the git package prior use.
 .IP "-e --email"
 The e-mail address associated with a subscription in SCC. Only use this option
 for BYOS instances and in conjunction with "--regcode" option.

--- a/package/fix-for-sles12-disable-registry.patch
+++ b/package/fix-for-sles12-disable-registry.patch
@@ -1,10 +1,10 @@
 diff --git a/cloudregister/registercloudguest.py b/cloudregister/registercloudguest.py
-index 7b9f3f0..d11cde5 100644
+index 43a5480..6c29eb0 100644
 --- a/cloudregister/registercloudguest.py
 +++ b/cloudregister/registercloudguest.py
-@@ -138,6 +138,8 @@ def setup_registry(registration_target, clean='registry'):
-     clean == all -> cleans repository and registry setup
-     clean == registry -> clean only registry artifacts
+@@ -150,6 +150,8 @@ def setup_registry(registration_target):
+     """
+     Run the registration process for the container registry
      """
 +    # Disabled on SLE12
 +    return None
@@ -12,7 +12,7 @@ index 7b9f3f0..d11cde5 100644
          utils.get_credentials_file(registration_target)
      )
 diff --git a/cloudregister/registerutils.py b/cloudregister/registerutils.py
-index ded03ef..54d7aa5 100644
+index 9d0f948..8b4ddf9 100644
 --- a/cloudregister/registerutils.py
 +++ b/cloudregister/registerutils.py
 @@ -29,7 +29,8 @@ import stat
@@ -25,7 +25,7 @@ index ded03ef..54d7aa5 100644
  import yaml
  
  from collections import namedtuple
-@@ -81,11 +82,12 @@ def add_hosts_entry(smt_server):
+@@ -93,11 +94,12 @@ def add_hosts_entry(smt_server):
          smt_server.get_FQDN(),
          smt_server.get_name()
      )
@@ -41,9 +41,9 @@ index ded03ef..54d7aa5 100644
 +    #         smt_server.get_registry_FQDN()
 +    #     )
  
+     etc_manage('/etc/hosts')
      with open('/etc/hosts', 'a') as hosts_file:
-         hosts_file.write(smt_hosts_entry_comment)
-@@ -913,6 +915,8 @@ def set_container_engines_env_vars():
+@@ -975,6 +977,8 @@ def set_container_engines_env_vars():
  
  # ----------------------------------------------------------------------------
  def get_registry_conf_file(container_path, container):
@@ -52,7 +52,7 @@ index ded03ef..54d7aa5 100644
      registries_conf = {}
      try:
          with open(container_path, 'r') as registries_conf_file:
-@@ -959,6 +963,8 @@ def update_bashrc(content, mode):
+@@ -1022,6 +1026,8 @@ def update_bashrc(content, mode):
  # ----------------------------------------------------------------------------
  def clean_registry_setup():
      """Remove the data previously set to make the registry work."""
@@ -61,12 +61,12 @@ index ded03ef..54d7aa5 100644
      smt = get_smt_from_store(_get_registered_smt_file_path())
      private_registry_fqdn = smt.get_registry_FQDN() if smt else ''
      clean_registry_auth(private_registry_fqdn)
-@@ -1229,6 +1235,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
+@@ -1292,6 +1298,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
  # ----------------------------------------------------------------------------
  def write_registries_conf(registries_conf, container_path, container_name):
      """Write registries_conf content to container_path."""
 +    # Disabled on SLE12
 +    return None
+     etc_manage(container_path)
      try:
          if container_name == 'podman':
-             with open(container_path, 'w') as registries_conf_file:

--- a/test/unit/exceptions_test.py
+++ b/test/unit/exceptions_test.py
@@ -1,0 +1,8 @@
+from cloudregister.exceptions import CloudRegisterPathError
+
+
+class TestCloudRegister:
+    def test_raise_message_representation(self):
+        exception = CloudRegisterPathError('some_error')
+        message = format(exception)
+        assert message == 'some_error'

--- a/test/unit/git_test.py
+++ b/test/unit/git_test.py
@@ -1,0 +1,247 @@
+from unittest.mock import (
+    patch, call, Mock
+)
+from pytest import (
+    raises, fixture
+)
+from cloudregister.logger import Logger
+from cloudregister.git import (
+    Git,
+    managed_file_type
+)
+from cloudregister.exceptions import (
+    CloudRegisterGitError,
+    CloudRegisterScopeError,
+    CloudRegisterPathError
+)
+
+log_instance = Logger()
+log = Logger.get_logger()
+
+
+class TestGit:
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    @patch('os.path.isdir')
+    @patch('os.path.isfile')
+    @patch('cloudregister.git.exec_subprocess')
+    @patch('cloudregister.git.clean_all_legacy')
+    @patch('cloudregister.git.Path')
+    @patch.object(Git, 'is_empty')
+    def setup(
+        self, mock_is_empty, mock_Path, mock_clean_all_legacy,
+        mock_exec_subprocess, mock_os_path_isfile, mock_os_path_isdir
+    ):
+        mock_exec_subprocess.return_value = (b'stdout', b'stderr', 1)
+        mock_os_path_isdir.return_value = False
+        mock_os_path_isfile.return_value = True
+        self.git = Git('/some')
+
+        # test legacy cleanup and init
+        mock_clean_all_legacy.assert_called_once_with()
+        assert mock_exec_subprocess.call_args_list == [
+            call(['git', 'init', '/some']),
+            call(
+                [
+                    'git', '--work-tree', '/some', '--git-dir', '/some/.git',
+                    'config', 'user.email', 'public-cloud-dev@susecloud.net'
+                ]
+            ),
+            call(
+                [
+                    'git', '--work-tree', '/some', '--git-dir', '/some/.git',
+                    'config', 'user.name', 'Public Cloud Team'
+                ]
+            )
+        ]
+
+        # test context manager cleanup
+        mock_is_empty.return_value = True
+        with Git('/some') as some_manage:
+            some_manage.managed_files['some'] = managed_file_type(
+                new=True, done=False
+            )
+        mock_Path.return_value.unlink.assert_called_once_with()
+
+        # test init exception
+        mock_exec_subprocess.side_effect = Exception
+        with raises(CloudRegisterGitError):
+            self.git = Git('/some')
+
+    @patch('os.path.isdir')
+    @patch('os.path.isfile')
+    @patch('cloudregister.git.exec_subprocess')
+    @patch('cloudregister.git.clean_all_legacy')
+    @patch('cloudregister.git.Path')
+    @patch.object(Git, 'is_empty')
+    def setup_method(
+        self, cls, mock_is_empty, mock_Path, mock_clean_all_legacy,
+        mock_exec_subprocess, mock_os_path_isfile, mock_os_path_isdir
+    ):
+        self.setup()
+
+    @patch('cloudregister.git.exec_subprocess')
+    def test_known_to_git(self, mock_exec_subprocess):
+        mock_exec_subprocess.return_value = (b'', b'', 0)
+        assert self.git._known_to_git('some') is True
+        mock_exec_subprocess.assert_called_once_with(
+            [
+                'git',
+                '--work-tree', '/some',
+                '--git-dir', '/some/.git',
+                'ls-files', '--error-unmatch',
+                'some'
+            ]
+        )
+        mock_exec_subprocess.return_value = (b'', b'', 1)
+        assert self.git._known_to_git('some') is False
+
+    @patch('os.path.exists')
+    @patch('cloudregister.git.Path')
+    def test_is_empty(self, mock_Path, mock_os_path_exists):
+        path = Mock()
+        path.stat.return_value = Mock(
+            st_size=0
+        )
+        mock_Path.return_value = path
+        mock_os_path_exists.return_value = False
+        assert self.git.is_empty('some') is True
+        mock_os_path_exists.return_value = True
+        assert self.git.is_empty('some') is True
+        path.stat.return_value = Mock(
+            st_size=1
+        )
+        assert self.git.is_empty('some') is False
+
+    @patch('os.path.exists')
+    @patch.object(Git, '_is_managed')
+    @patch.object(Git, '_manage_new')
+    @patch.object(Git, '_manage_existing')
+    def test_manage(
+        self, mock_manage_existing, mock_manage_new,
+        mock_is_managed, mock_os_path_exists
+    ):
+        mock_is_managed.return_value = False
+        mock_os_path_exists.return_value = False
+        self.git.manage('some')
+        mock_manage_new.assert_called_once_with('some')
+        mock_os_path_exists.return_value = True
+        self.git.manage('some')
+        mock_manage_existing.assert_called_once_with('some')
+
+    def test_done(self):
+        self.git.managed_files['some'] = managed_file_type(
+            new=True, done=False
+        )
+        self.git.managed_files['other'] = managed_file_type(
+            new=True, done=False
+        )
+        self.git.done()
+        assert self.git.managed_files['some'].done is True
+
+    @patch('cloudregister.git.exec_subprocess')
+    @patch('cloudregister.git.Path')
+    @patch.object(Git, 'is_empty')
+    def test_cleanup(self, mock_is_empty, mock_Path, mock_exec_subprocess):
+        mock_exec_subprocess.return_value = (b'some_modified_file', b'', 0)
+        mock_is_empty.return_value = True
+        self.git.cleanup()
+        assert mock_exec_subprocess.call_args_list == [
+            call(
+                [
+                    'git',
+                    '--work-tree', '/some',
+                    '--git-dir', '/some/.git',
+                    'ls-files', '-m'
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree', '/some',
+                    '--git-dir', '/some/.git',
+                    'checkout', '/some/some_modified_file'
+                ]
+            )
+        ]
+        mock_exec_subprocess.return_value = (b'some_modified_file', '', 1)
+        self.git.cleanup()
+        assert 'Could not checkout origin' in self._caplog.text
+
+    def test_is_managed(self):
+        assert self.git._is_managed('/some') is False
+        with raises(CloudRegisterScopeError):
+            self.git._is_managed('other')
+        self.git.managed_files['/some'] = managed_file_type(
+            new=True, done=False
+        )
+        assert self.git._is_managed('/some') is True
+
+    @patch('cloudregister.git.exec_subprocess')
+    def test_manage_new(self, mock_exec_subprocess):
+        mock_exec_subprocess.return_value = (b'', b'', 0)
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.side_effect = Exception
+            with raises(CloudRegisterPathError):
+                self.git._manage_new('some')
+
+        with patch('builtins.open', create=True):
+            self.git._manage_new('some')
+            assert mock_exec_subprocess.call_args_list == [
+                call(
+                    [
+                        'git',
+                        '--work-tree', '/some',
+                        '--git-dir', '/some/.git',
+                        'add', 'some'
+                    ]
+                ),
+                call(
+                    [
+                        'git',
+                        '--work-tree', '/some',
+                        '--git-dir', '/some/.git',
+                        'commit', '--allow-empty', '-m',
+                        'origin:some'
+                    ]
+                )
+            ]
+
+        mock_exec_subprocess.return_value = (b'', b'', 1)
+        with patch('builtins.open', create=True):
+            with raises(CloudRegisterGitError):
+                self.git._manage_new('some')
+
+    @patch('cloudregister.git.exec_subprocess')
+    @patch.object(Git, '_known_to_git')
+    def test_manage_existing(self, mock_known_to_git, mock_exec_subprocess):
+        mock_known_to_git.return_value = True
+        self.git._manage_existing('some')
+        assert 'already managed' in self._caplog.text
+        mock_known_to_git.return_value = False
+        mock_exec_subprocess.return_value = (b'', b'', 1)
+        with raises(CloudRegisterGitError):
+            self.git._manage_existing('some')
+        mock_exec_subprocess.reset_mock()
+        mock_exec_subprocess.return_value = (b'', b'', 0)
+        self.git._manage_existing('some')
+        assert mock_exec_subprocess.call_args_list == [
+            call(
+                [
+                    'git',
+                    '--work-tree', '/some',
+                    '--git-dir', '/some/.git',
+                    'add', 'some'
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree', '/some',
+                    '--git-dir', '/some/.git',
+                    'commit', '-m', 'origin:some'
+                ]
+            )
+         ]

--- a/test/unit/registercloudguest_test.py
+++ b/test/unit/registercloudguest_test.py
@@ -43,7 +43,7 @@ class TestRegisterCloudGuest:
             user_smt_fp=None
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     @patch('cloudregister.registerutils.has_network_access_by_ip_address')
     def test_register_cloud_guest_no_connection_ip(self, mock_has_network):
@@ -54,7 +54,7 @@ class TestRegisterCloudGuest:
             user_smt_fp='AA:BB:CC:DD'
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     def test_register_cloud_guest_non_ip_value(self):
         fake_args = SimpleNamespace(
@@ -63,7 +63,7 @@ class TestRegisterCloudGuest:
             user_smt_fp='AA:BB:CC'
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     def test_register_cloud_guest_mixed_param(self):
         fake_args = SimpleNamespace(
@@ -75,7 +75,7 @@ class TestRegisterCloudGuest:
             debug=True
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     def test_register_cloud_guest_no_regcode_email(self):
         fake_args = SimpleNamespace(
@@ -89,22 +89,20 @@ class TestRegisterCloudGuest:
             debug=True
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     @patch('cloudregister.registerutils.clean_hosts_file')
-    @patch('cloudregister.registerutils.clean_non_free_extensions')
+    @patch('cloudregister.registerutils.deregister_non_free_extensions')
     @patch('time.sleep')
     @patch('cloudregister.registerutils.get_config')
     @patch('cloudregister.registerutils.clean_framework_identifier')
     @patch('cloudregister.registerutils.clear_new_registration_flag')
     @patch('cloudregister.registerutils.clean_smt_cache')
-    @patch('cloudregister.registerutils.remove_registration_data')
-    @patch('cloudregister.registerutils.clean_registry_setup')
     def test_register_cloud_guest_cleanup(
         self,
-        mock_clean_reg_setup, mock_remove_reg_data, mock_clean_smt_cache,
+        mock_clean_smt_cache,
         mock_clear_reg_flag, mock_framework_id,  mock_get_config, mock_time_sleep,
-        mock_clean_non_free_extensions, mock_clean_hosts_file
+        mock_deregister_non_free_extensions, mock_clean_hosts_file
     ):
         fake_args = SimpleNamespace(
             clean_up=True,
@@ -119,39 +117,7 @@ class TestRegisterCloudGuest:
             debug=False
         )
         with raises(SystemExit):
-            register_cloud_guest.main(fake_args)
-        mock_clean_reg_setup.assert_called_once()
-
-    @patch('cloudregister.registerutils.clean_non_free_extensions')
-    @patch('time.sleep')
-    @patch('cloudregister.registerutils.get_config')
-    @patch('cloudregister.registerutils.clean_framework_identifier')
-    @patch('cloudregister.registerutils.clear_new_registration_flag')
-    @patch('cloudregister.registerutils.clean_smt_cache')
-    @patch('cloudregister.registerutils.remove_registration_data')
-    @patch('cloudregister.registerutils.clean_registry_setup')
-    def test_register_cloud_guest_cleanup_exception(
-        self,
-        mock_clean_reg_setup, mock_remove_reg_data, mock_clean_smt_cache,
-        mock_clear_reg_flag, mock_framework_id,  mock_get_config, mock_time_sleep,
-        mock_clean_non_free_extensions
-    ):
-        fake_args = SimpleNamespace(
-            clean_up=True,
-            force_new_registration=False,
-            user_smt_ip=None,
-            user_smt_fqdn=None,
-            user_smt_fp=None,
-            email=None,
-            reg_code=None,
-            delay_time=1,
-            config_file='config_file',
-            debug=True
-        )
-        mock_clean_non_free_extensions.side_effect = Exception('oh no')
-        with raises(SystemExit):
-            register_cloud_guest.main(fake_args)
-        mock_clean_reg_setup.assert_called_once()
+            register_cloud_guest.main(fake_args, Mock())
 
     @patch('cloudregister.registerutils.set_registration_completed_flag')
     @patch('cloudregister.registerutils.set_new_registration_flag')
@@ -193,7 +159,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
 
     @patch('cloudregister.registerutils.set_new_registration_flag')
@@ -235,7 +201,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
 
     @patch.object(SMT, 'is_equivalent')
@@ -310,7 +276,7 @@ class TestRegisterCloudGuest:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
             with self._caplog.at_level(logging.DEBUG):
-                register_cloud_guest.main(fake_args)
+                register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
         assert 'Configured update server is unresponsive' in self._caplog.text
 
@@ -392,8 +358,93 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
+
+    @patch('cloudregister.registerutils.set_proxy')
+    @patch('cloudregister.registerutils.update_rmt_cert')
+    @patch('cloudregister.registerutils.has_registry_in_hosts')
+    @patch('cloudregister.registerutils.add_hosts_entry')
+    @patch('cloudregister.registerutils.clean_hosts_file')
+    @patch('cloudregister.registerutils.has_rmt_in_hosts')
+    @patch('cloudregister.registerutils.os.path.exists')
+    @patch.object(SMT, 'is_responsive')
+    @patch('cloudregister.registercloudguest.setup_ltss_registration')
+    @patch('cloudregister.registercloudguest.setup_registry')
+    @patch('cloudregister.registerutils.get_instance_data')
+    @patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+    @patch('cloudregister.registerutils.has_region_changed')
+    @patch('cloudregister.registerutils.store_smt_data')
+    @patch('cloudregister.registerutils.get_current_smt')
+    @patch('cloudregister.registerutils.set_new_registration_flag')
+    @patch('cloudregister.registerutils.has_network_access_by_ip_address')
+    @patch('cloudregister.registerutils.is_zypper_running')
+    @patch('cloudregister.registerutils.write_framework_identifier')
+    @patch('cloudregister.registerutils.get_available_smt_servers')
+    @patch('os.makedirs')
+    @patch('os.path.isdir')
+    @patch('time.sleep')
+    @patch('cloudregister.registerutils.get_state_dir')
+    @patch('cloudregister.registerutils.get_config')
+    @patch('cloudregister.registercloudguest.cleanup')
+    @patch('cloudregister.registerutils.clean_registry_setup')
+    def test_register_cloud_guest_registry_setup_failed(
+        self,
+        mock_clean_registry_setup,
+        mock_cleanup, mock_get_config,
+        mock_get_state_dir, mock_time_sleep,
+        mock_os_path_isdir, mock_os_makedirs,
+        mock_get_available_smt_servers, mock_write_framework_id,
+        mock_is_zypper_running, mock_has_network_access,
+        mock_set_new_registration_flag, mock_get_current_smt,
+        mock_store_smt_data,
+        mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+        mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+        mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+        mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+        mock_update_rmt_cert, mock_set_proxy
+    ):
+        mock_set_proxy.return_value = True
+        smt_data_ipv46 = dedent('''\
+            <smtInfo fingerprint="AA:BB:CC:DD"
+             SMTserverIP="1.2.3.5"
+             SMTserverIPv6="fc00::1"
+             SMTserverName="foo-ec2.susecloud.net"
+             SMTregistryName="registry-ec2.susecloud.net"
+             region="antarctica-1"/>''')
+
+        smt_server = SMT(etree.fromstring(smt_data_ipv46))
+        mock_get_current_smt.return_value = smt_server
+        fake_args = SimpleNamespace(
+            clean_up=False,
+            force_new_registration=True,
+            user_smt_ip='1.2.3.5',
+            user_smt_fqdn='foo-ec2.susecloud.net',
+            user_smt_fp='AA:BB:CC:DD',
+            email=None,
+            reg_code='super_reg_code',
+            delay_time=1,
+            config_file='config_file',
+            debug=True
+        )
+        mock_os_path_isdir.return_value = False
+        mock_is_zypper_running.return_value = False
+        mock_get_available_smt_servers.return_value = []
+        mock_has_network_access.return_value = True
+        mock_has_region_changed.return_value = True
+        mock_uses_rmt_as_scc_proxy.return_value = True
+        mock_get_instance_data.return_value = None
+        mock_smt_is_responsive.return_value = True
+        mock_os_path_exists.return_value = True
+        mock_update_rmt_cert.return_value = True
+        mock_has_rmt_in_hosts.return_value = False
+        mock_has_registry_in_hosts.return_value = False
+        mock_setup_registry.return_value = False
+        with tempfile.TemporaryDirectory(suffix='foo') as tdir:
+            mock_get_state_dir.return_value = tdir
+        with raises(SystemExit) as sys_exit:
+            register_cloud_guest.main(fake_args, None)
+            assert sys_exit.value.code == 1
 
     @patch('cloudregister.registerutils.set_proxy')
     @patch('cloudregister.registerutils.update_rmt_cert')
@@ -474,7 +525,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.replace_hosts_entry')
@@ -562,7 +613,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -643,7 +694,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -729,7 +780,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
             assert 'No registration executable found' in self._caplog.text
             assert sys_exit.value.code == 1
 
@@ -819,7 +870,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -909,7 +960,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert 'No products installed on system' in self._caplog.text
         assert sys_exit.value.code == 1
 
@@ -1002,7 +1053,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
         assert 'SMT certificate import failed' in self._caplog.text
 
@@ -1037,10 +1088,17 @@ class TestRegisterCloudGuest:
     @patch('time.sleep')
     @patch('cloudregister.registerutils.get_state_dir')
     @patch('cloudregister.registerutils.get_config')
-    @patch('cloudregister.registercloudguest.cleanup')
+    @patch('cloudregister.registerutils.deregister_non_free_extensions')
+    @patch('cloudregister.registerutils.deregister_from_update_infrastructure')
+    @patch('cloudregister.registerutils.deregister_from_SCC')
+    @patch('cloudregister.registerutils.clean_cache')
     def test_register_cloud_guest_force_baseprod_registration_failed(
         self,
-        mock_cleanup, mock_get_config,
+        mock_clean_cache,
+        mock_deregister_from_SCC,
+        mock_deregister_from_update_infrastructure,
+        mock_deregister_non_free_extensions,
+        mock_get_config,
         mock_get_state_dir, mock_time_sleep,
         mock_os_path_isdir, mock_os_makedirs,
         mock_get_available_smt_servers, mock_write_framework_id,
@@ -1104,139 +1162,8 @@ class TestRegisterCloudGuest:
             error='stderr'
         )
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert 'Baseproduct registration failed' in self._caplog.text
-        assert sys_exit.value.code == 1
-
-    @patch('cloudregister.registerutils._remove_state_file')
-    @patch('cloudregister.registerutils.set_registration_completed_flag')
-    @patch('cloudregister.registerutils.set_proxy')
-    @patch.object(SMT, 'is_equivalent')
-    @patch('cloudregister.registerutils.is_registration_supported')
-    @patch('cloudregister.registercloudguest.get_responding_update_server')
-    @patch('cloudregister.registerutils.fetch_smt_data')
-    @patch('cloudregister.registerutils.remove_registration_data')
-    @patch('cloudregister.registerutils.register_product')
-    @patch('cloudregister.registerutils.import_smt_cert')
-    @patch('cloudregister.registerutils.get_installed_products')
-    @patch('cloudregister.registerutils.set_as_current_smt')
-    @patch('os.access')
-    @patch('cloudregister.registerutils.get_register_cmd')
-    @patch('cloudregister.registerutils.update_rmt_cert')
-    @patch('cloudregister.registerutils.has_registry_in_hosts')
-    @patch('cloudregister.registerutils.add_hosts_entry')
-    @patch('cloudregister.registerutils.clean_hosts_file')
-    @patch('cloudregister.registerutils.has_rmt_in_hosts')
-    @patch('cloudregister.registerutils.os.path.exists')
-    @patch.object(SMT, 'is_responsive')
-    @patch('cloudregister.registercloudguest.setup_ltss_registration')
-    @patch('cloudregister.registercloudguest.setup_registry')
-    @patch('cloudregister.registerutils.get_instance_data')
-    @patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
-    @patch('cloudregister.registerutils.has_region_changed')
-    @patch('cloudregister.registerutils.store_smt_data')
-    @patch('cloudregister.registerutils.get_current_smt')
-    @patch('cloudregister.registerutils.set_new_registration_flag')
-    @patch('cloudregister.registerutils.has_network_access_by_ip_address')
-    @patch('cloudregister.registerutils.is_zypper_running')
-    @patch('cloudregister.registerutils.write_framework_identifier')
-    @patch('cloudregister.registerutils.get_available_smt_servers')
-    @patch('os.makedirs')
-    @patch('os.path.isdir')
-    @patch('time.sleep')
-    @patch('cloudregister.registerutils.get_state_dir')
-    @patch('cloudregister.registerutils.get_config')
-    @patch('cloudregister.registercloudguest.cleanup')
-    def test_register_cloud_guest_force_baseprod_registration_failed_connection(
-        self,
-        mock_cleanup, mock_get_config,
-        mock_get_state_dir, mock_time_sleep,
-        mock_os_path_isdir, mock_os_makedirs,
-        mock_get_available_smt_servers, mock_write_framework_id,
-        mock_is_zypper_running, mock_has_network_access,
-        mock_set_new_registration_flag, mock_get_current_smt,
-        mock_store_smt_data,
-        mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
-        mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
-        mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
-        mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
-        mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
-        mock_set_as_current_smt, mock_get_installed_products,
-        mock_import_smt_cert, mock_register_product, mock_remove_reg_data,
-        mock_fetch_smt_data, mock_get_responding_update_server,
-        mock_is_reg_supported, mock_is_equivalent, mock_set_proxy,
-        mock_set_registration_completed_flag, mock_remove_state_file
-    ):
-        smt_data_ipv46 = dedent('''\
-            <smtInfo fingerprint="AA:BB:CC:DD"
-             SMTserverIP="1.2.3.5"
-             SMTserverIPv6="fc00::1"
-             SMTserverName="foo-ec2.susecloud.net"
-             SMTregistryName="registry-ec2.susecloud.net"
-             region="antarctica-1"/>''')
-
-        smt_region_data = dedent('''\
-            <regionSMTdata><smtInfo fingerprint="AA:BB:CC:DD"
-             SMTserverIP="1.2.3.5"
-             SMTserverIPv6="fc00::1"
-             SMTserverName="foo-ec2.susecloud.net"
-             SMTregistryName="registry-ec2.susecloud.net"
-             region="antarctica-1"/><smtInfo fingerprint="AA:BB:CC:DD"
-             SMTserverIP="1.2.3.6"
-             SMTserverIPv6="fc00::1"
-             SMTserverName="foo-ec2.susecloud.net"
-             SMTregistryName="registry-ec2.susecloud.net"
-             region="antarctica-1"/></regionSMTdata>''')
-
-        smt_server = SMT(etree.fromstring(smt_data_ipv46))
-        mock_get_current_smt.return_value = smt_server
-        fake_args = SimpleNamespace(
-            clean_up=False,
-            force_new_registration=True,
-            user_smt_ip=None,
-            user_smt_fqdn=None,
-            user_smt_fp=None,
-            email=None,
-            reg_code='super_reg_code',
-            delay_time=1,
-            config_file='config_file',
-            debug=True
-        )
-        mock_os_path_isdir.return_value = False
-        mock_is_zypper_running.return_value = False
-        mock_get_available_smt_servers.return_value = [smt_server, smt_server]
-        mock_get_responding_update_server.return_value = smt_server
-        mock_has_network_access.return_value = True
-        mock_has_region_changed.return_value = True
-        mock_uses_rmt_as_scc_proxy.return_value = False
-        mock_get_instance_data.return_value = None
-        mock_smt_is_responsive.return_value = False
-        mock_is_equivalent.return_value = False
-        mock_set_proxy.return_value = False
-        mock_os_path_exists.side_effect = [True, True]
-        mock_update_rmt_cert.return_value = True
-        mock_has_rmt_in_hosts.return_value = False
-        mock_has_registry_in_hosts.return_value = False
-        mock_os_access.return_value = True
-        mock_get_installed_products.return_value = 'foo'
-        mock_import_smt_cert.return_value = True
-        mock_remove_state_file.return_value = True
-        with tempfile.TemporaryDirectory(suffix='foo') as tdir:
-            mock_get_state_dir.return_value = tdir
-        prod_reg_type = namedtuple(
-            'prod_reg_type', ['returncode', 'output', 'error']
-        )
-        mock_register_product.return_value = prod_reg_type(
-            returncode=64,
-            output='some error',
-            error='stderr'
-        )
-        mock_fetch_smt_data.return_value = etree.fromstring(smt_region_data)
-        mock_is_reg_supported.return_value = True
-        with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
-        assert 'Baseproduct registration failed' in self._caplog.text
-        assert 'some error' in self._caplog.text
         assert sys_exit.value.code == 1
 
     @patch('cloudregister.registerutils._remove_state_file')
@@ -1366,7 +1293,7 @@ class TestRegisterCloudGuest:
         )
         mock_set_proxy.return_value = False
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert 'Unable to obtain product information from server "1.2.3.5,None"' in \
             self._caplog.text
         assert 'Unable to register modules, exiting.' in self._caplog.text
@@ -1410,10 +1337,17 @@ class TestRegisterCloudGuest:
     @patch('time.sleep')
     @patch('cloudregister.registerutils.get_state_dir')
     @patch('cloudregister.registerutils.get_config')
-    @patch('cloudregister.registercloudguest.cleanup')
+    @patch('cloudregister.registerutils.deregister_non_free_extensions')
+    @patch('cloudregister.registerutils.deregister_from_update_infrastructure')
+    @patch('cloudregister.registerutils.deregister_from_SCC')
+    @patch('cloudregister.registerutils.clean_cache')
     def test_register_cloud_guest_force_baseprod_extensions_raise(
         self,
-        mock_cleanup, mock_get_config,
+        mock_clean_cache,
+        mock_deregister_from_SCC,
+        mock_deregister_from_update_infrastructure,
+        mock_deregister_non_free_extensions,
+        mock_get_config,
         mock_get_state_dir, mock_time_sleep,
         mock_os_path_isdir, mock_os_makedirs,
         mock_get_available_smt_servers, mock_write_framework_id,
@@ -1541,7 +1475,7 @@ class TestRegisterCloudGuest:
         mock_set_proxy.return_value = False
         mock_get_register_cmd.return_value = '/usr/sbin/SUSEConnect'
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 6
 
     @patch('cloudregister.registerutils.set_registration_completed_flag')
@@ -1733,7 +1667,7 @@ class TestRegisterCloudGuest:
             query='highlight=params', fragment='url-parsing'
         )
         mock_set_proxy.return_value = False
-        assert register_cloud_guest.main(fake_args) is None
+        assert register_cloud_guest.main(fake_args, Mock()) is None
         assert 'Forced new registration' in self._caplog.text
         assert 'Using user specified SMT server:\n\n\t"IP:1.2.3.5"\n\t"' in self._caplog.text
         assert 'Region change detected, registering to new servers' in self._caplog.text
@@ -1928,7 +1862,7 @@ class TestRegisterCloudGuest:
             query='highlight=params', fragment='url-parsing'
         )
         mock_set_proxy.return_value = False
-        assert register_cloud_guest.main(fake_args) is None
+        assert register_cloud_guest.main(fake_args, Mock()) is None
         assert 'Forced new registration' in self._caplog.text
         assert 'Using user specified SMT server:\n\n\t"IP:fc00::1"\n\t"' in self._caplog.text
         assert 'Region change detected, registering to new servers' in self._caplog.text
@@ -2132,7 +2066,7 @@ class TestRegisterCloudGuest:
         )
         mock_set_proxy.return_value = False
 
-        assert register_cloud_guest.main(fake_args) is None
+        assert register_cloud_guest.main(fake_args, Mock()) is None
 
         assert 'Registration succeeded' in self._caplog.text
         assert 'There are products that were not registered' in self._caplog.text
@@ -2335,7 +2269,7 @@ class TestRegisterCloudGuest:
         )
         with raises(SystemExit) as sys_exit:
             with patch('builtins.open', mock_open()):
-                register_cloud_guest.main(fake_args)
+                register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 0
         assert 'Region change detected, registering to new servers' in self._caplog.text
 
@@ -2446,32 +2380,6 @@ class TestRegisterCloudGuest:
             'registry-ec2.susecloud.net'
         )
 
-    @patch('cloudregister.registercloudguest.cleanup')
-    @patch('cloudregister.registerutils.prepare_registry_setup')
-    @patch('cloudregister.registerutils.is_registry_registered')
-    @patch('cloudregister.registerutils.get_credentials_file')
-    @patch('cloudregister.registerutils.get_credentials')
-    def test_setup_clean_all(
-        self,
-        mock_get_credentials, mock_get_credentials_file,
-        mock_is_registry_registered, mock_prepare_registry_setup,
-        mock_cleanup
-    ):
-        smt_data_ipv46 = dedent('''\
-            <smtInfo fingerprint="AA:BB:CC:DD"
-             SMTserverIP="1.2.3.5"
-             SMTserverIPv6="fc00::1"
-             SMTserverName="foo-ec2.susecloud.net"
-             SMTregistryName="registry-ec2.susecloud.net"
-             region="antarctica-1"/>''')
-        smt_server = SMT(etree.fromstring(smt_data_ipv46))
-        mock_get_credentials.return_value = 'foo', 'bar'
-        mock_is_registry_registered.return_value = False
-        mock_prepare_registry_setup.return_value = False
-        with raises(SystemExit) as sys_exit:
-            register_cloud_guest.setup_registry(smt_server, 'all')
-        assert sys_exit.value.code == 1
-
     @patch('cloudregister.registerutils.clean_registry_setup')
     @patch('cloudregister.registerutils.prepare_registry_setup')
     @patch('cloudregister.registerutils.is_registry_registered')
@@ -2494,9 +2402,7 @@ class TestRegisterCloudGuest:
         mock_get_credentials.return_value = 'foo', 'bar'
         mock_is_registry_registered.return_value = False
         mock_prepare_registry_setup.return_value = False
-        with raises(SystemExit) as sys_exit:
-            register_cloud_guest.setup_registry(smt_server)
-        assert sys_exit.value.code == 1
+        assert register_cloud_guest.setup_registry(smt_server) is False
 
     @patch('cloudregister.registerutils.prepare_registry_setup')
     @patch('cloudregister.registerutils.set_registries_conf_podman')
@@ -2531,7 +2437,7 @@ class TestRegisterCloudGuest:
         mock_set_registries_conf_podman.return_value = True
         mock_set_registries_conf_docker.return_value = True
         mock_set_registry_fqdn_suma.return_value = True
-        assert register_cloud_guest.setup_registry(smt_server) is None
+        assert register_cloud_guest.setup_registry(smt_server) is True
         mock_set_registries_conf_podman.assert_called_once_with(
             'registry-ec2.susecloud.net'
         )
@@ -2574,7 +2480,7 @@ class TestRegisterCloudGuest:
         mock_prepare_registry_setup.return_value = True
         mock_set_registries_conf_podman.return_value = True
         mock_set_registry_fqdn_suma.return_value = True
-        assert register_cloud_guest.setup_registry(smt_server) is None
+        assert register_cloud_guest.setup_registry(smt_server) is True
         assert not mock_set_registries_conf_docker.called
 
     def test_get_responding_update_server_error(self):
@@ -2691,3 +2597,286 @@ class TestRegisterCloudGuest:
         assert sys_exit.value.code == 1
         assert 'LTSS registration failed' in self._caplog.text
         assert '\tnot OK' in self._caplog.text
+
+    @patch('cloudregister.registerutils.register_product')
+    @patch('cloudregister.registerutils.add_hosts_entry')
+    @patch('cloudregister.registercloudguest.cleanup')
+    @patch('cloudregister.registerutils.clear_rmt_as_scc_proxy_flag')
+    @patch('cloudregister.registerutils.deregister_non_free_extensions')
+    @patch('cloudregister.registerutils.deregister_from_update_infrastructure')
+    @patch('cloudregister.registerutils.deregister_from_SCC')
+    @patch('cloudregister.registerutils.clean_registered_smt_data_file')
+    @patch('cloudregister.registerutils.clean_hosts_file')
+    @patch('cloudregister.registerutils.clear_new_registration_flag')
+    @patch('cloudregister.registerutils.set_rmt_as_scc_proxy_flag')
+    def test_register_base_product(
+        self,
+        mock_set_rmt_as_scc_proxy_flag,
+        mock_clear_new_registration_flag,
+        mock_clean_hosts_file,
+        mock_clean_registered_smt_data_file,
+        mock_deregister_from_SCC,
+        mock_deregister_from_update_infrastructure,
+        mock_deregister_non_free_extensions,
+        mock_clear_rmt_as_scc_proxy_flag,
+        mock_cleanup, mock_add_hosts_entry,
+        mock_register_product
+    ):
+        prod_reg = Mock()
+        prod_reg.returncode = 0
+        prod_reg.output = 'zypper output'
+        mock_register_product.return_value = prod_reg
+        registration_target = Mock()
+        instance_data_filepath = 'some'
+        commandline_args = Mock()
+        region_smt_servers = [Mock(), Mock()]
+        # Test success case
+        register_cloud_guest.register_base_product(
+            registration_target, instance_data_filepath,
+            commandline_args, region_smt_servers
+        )
+        assert 'Baseproduct registration complete' in self._caplog.text
+        mock_clear_new_registration_flag.assert_called_once_with()
+        mock_set_rmt_as_scc_proxy_flag.assert_called_once_with()
+
+        # Test error case
+        prod_reg.returncode = 1
+        with raises(SystemExit):
+            register_cloud_guest.register_base_product(
+                registration_target, instance_data_filepath,
+                commandline_args, region_smt_servers
+            )
+            mock_deregister_non_free_extensions.assert_called_once_with()
+            mock_clear_rmt_as_scc_proxy_flag.assert_called_once_with()
+            mock_deregister_non_free_extensions.assert_called_once_with()
+            mock_deregister_from_update_infrastructure.assert_called_once_with()
+            mock_deregister_from_SCC.assert_called_once_with()
+            mock_clean_registered_smt_data_file.assert_called_once_with()
+            mock_clean_hosts_file.assert_called_once_with()
+
+    @patch('cloudregister.registerutils.deregister_non_free_extensions')
+    @patch('cloudregister.registerutils.deregister_from_update_infrastructure')
+    @patch('cloudregister.registerutils.deregister_from_SCC')
+    @patch('cloudregister.registerutils.clean_cache')
+    @patch('cloudregister.registerutils.clean_all_legacy')
+    def test_cleanup(
+        self,
+        mock_clean_all_legacy,
+        mock_clean_cache,
+        mock_deregister_from_SCC,
+        mock_deregister_from_update_infrastructure,
+        mock_deregister_non_free_extensions
+    ):
+        etc_content = Mock()
+        # cleanup with content manager(git)...
+        register_cloud_guest.cleanup(etc_content)
+        mock_deregister_non_free_extensions.assert_called_once_with()
+        mock_deregister_from_update_infrastructure.assert_called_once_with()
+        mock_deregister_from_SCC.assert_called_once_with()
+        mock_clean_cache.assert_called_once_with()
+        etc_content.cleanup.assert_called_once_with()
+
+        # cleanup legacy style
+        register_cloud_guest.cleanup()
+        mock_clean_all_legacy.assert_called_once_with()
+
+    @patch('cloudregister.registerutils._remove_state_file')
+    @patch('cloudregister.registerutils.set_registration_completed_flag')
+    @patch('os.system')
+    @patch('cloudregister.registerutils.set_proxy')
+    @patch('cloudregister.registercloudguest.urllib.parse.urlparse')
+    @patch('cloudregister.registerutils.enable_repository')
+    @patch('cloudregister.registerutils.exec_subprocess')
+    @patch('cloudregister.registerutils.get_repo_url')
+    @patch('cloudregister.registerutils.find_repos')
+    @patch('cloudregister.registerutils.has_nvidia_support')
+    @patch('cloudregister.registercloudguest.registration_returncode', 0)
+    @patch('os.unlink')
+    @patch('cloudregister.registerutils.get_credentials_file')
+    @patch('cloudregister.registerutils.get_credentials')
+    @patch('cloudregister.registerutils.get_product_tree')
+    @patch('cloudregister.registerutils.requests.get')
+    @patch('cloudregister.registerutils.set_rmt_as_scc_proxy_flag')
+    @patch('cloudregister.registerutils.register_product')
+    @patch('cloudregister.registerutils.import_smt_cert')
+    @patch('cloudregister.registerutils.get_installed_products')
+    @patch('cloudregister.registerutils.set_as_current_smt')
+    @patch('os.access')
+    @patch('cloudregister.registerutils.get_register_cmd')
+    @patch('cloudregister.registerutils.update_rmt_cert')
+    @patch('cloudregister.registerutils.has_registry_in_hosts')
+    @patch('cloudregister.registerutils.add_hosts_entry')
+    @patch('cloudregister.registerutils.clean_hosts_file')
+    @patch('cloudregister.registerutils.has_rmt_in_hosts')
+    @patch('cloudregister.registerutils.os.path.exists')
+    @patch.object(SMT, 'is_responsive')
+    @patch('cloudregister.registercloudguest.setup_ltss_registration')
+    @patch('cloudregister.registercloudguest.setup_registry')
+    @patch('cloudregister.registerutils.get_instance_data')
+    @patch('cloudregister.registerutils.uses_rmt_as_scc_proxy')
+    @patch('cloudregister.registerutils.has_region_changed')
+    @patch('cloudregister.registerutils.store_smt_data')
+    @patch('cloudregister.registerutils.get_current_smt')
+    @patch('cloudregister.registerutils.set_new_registration_flag')
+    @patch('cloudregister.registerutils.has_network_access_by_ip_address')
+    @patch('cloudregister.registerutils.is_zypper_running')
+    @patch('cloudregister.registerutils.write_framework_identifier')
+    @patch('cloudregister.registerutils.get_available_smt_servers')
+    @patch('os.makedirs')
+    @patch('os.path.isdir')
+    @patch('time.sleep')
+    @patch('cloudregister.registerutils.get_state_dir')
+    @patch('cloudregister.registerutils.get_config')
+    @patch('cloudregister.registercloudguest.cleanup')
+    def test_reg_cloud_baseprod_ok_setup_registry_failed(
+        self,
+        mock_cleanup, mock_get_config,
+        mock_get_state_dir, mock_time_sleep,
+        mock_os_path_isdir, mock_os_makedirs,
+        mock_get_available_smt_servers, mock_write_framework_id,
+        mock_is_zypper_running, mock_has_network_access,
+        mock_set_new_registration_flag, mock_get_current_smt,
+        mock_store_smt_data,
+        mock_has_region_changed, mock_uses_rmt_as_scc_proxy,
+        mock_get_instance_data, mock_setup_registry, mock_setup_ltss_registration,
+        mock_smt_is_responsive, mock_os_path_exists, mock_has_rmt_in_hosts,
+        mock_clean_hosts_file, mock_add_hosts_entry, mock_has_registry_in_hosts,
+        mock_update_rmt_cert, mock_get_register_cmd, mock_os_access,
+        mock_set_as_current_smt, mock_get_installed_products,
+        mock_import_smt_cert, mock_register_product,
+        mock_set_rmt_as_scc_proxy_flag,
+        mock_requests_get, mock_get_product_tree, mock_get_creds,
+        mock_get_creds_file, mock_os_unlink, mock_has_nvidia_support,
+        mock_find_repos, mock_get_repo_url, mock_exec_subprocess, mock_enable_repo,
+        mock_urlparse, mock_set_proxy, mock_os_system,
+        mock_set_registration_completed_flag, mock_remove_state_file
+    ):
+        smt_data_ipv46 = dedent('''\
+            <smtInfo fingerprint="AA:BB:CC:DD"
+             SMTserverIP="1.2.3.5"
+             SMTserverIPv6="fc00::1"
+             SMTserverName="foo-ec2.susecloud.net"
+             SMTregistryName="registry-ec2.susecloud.net"
+             region="antarctica-1"/>''')
+        smt_server = SMT(etree.fromstring(smt_data_ipv46))
+        mock_get_current_smt.return_value = smt_server
+        fake_args = SimpleNamespace(
+            clean_up=False,
+            force_new_registration=True,
+            user_smt_ip='fc00::1',
+            user_smt_fqdn='foo-ec2.susecloud.net',
+            user_smt_fp='AA:BB:CC:DD',
+            email=None,
+            reg_code='super_reg_code',
+            delay_time=1,
+            config_file='config_file',
+            debug=True
+        )
+        mock_os_path_isdir.return_value = False
+        mock_is_zypper_running.return_value = False
+        mock_get_available_smt_servers.return_value = []
+        mock_has_network_access.return_value = True
+        mock_has_region_changed.return_value = True
+        mock_uses_rmt_as_scc_proxy.return_value = False
+        mock_get_instance_data.return_value = None
+        mock_smt_is_responsive.return_value = True
+        mock_os_path_exists.side_effect = [False, True, True, True]
+        mock_update_rmt_cert.return_value = True
+        mock_has_rmt_in_hosts.return_value = False
+        mock_has_registry_in_hosts.return_value = False
+        mock_os_access.return_value = True
+        mock_get_installed_products.return_value = 'SLES-LTSS-FOO/15.4/x86_64'
+        mock_import_smt_cert.return_value = True
+        mock_remove_state_file.return_value = True
+        with tempfile.TemporaryDirectory(suffix='foo') as tdir:
+            mock_get_state_dir.return_value = tdir
+        prod_reg_type = namedtuple(
+            'prod_reg_type', ['returncode', 'output', 'error']
+        )
+        mock_register_product.side_effect = [
+            prod_reg_type(
+                returncode=0,
+                output='all OK',
+                error='stderr'
+            ),
+            prod_reg_type(
+                returncode=67,
+                output='registration code',
+                error='stderr'
+            )
+        ]
+        response = Response()
+        response.status_code = requests.codes.ok
+        json_mock = Mock()
+        json_mock.return_value = {
+            'id': 2001,
+            'name': 'SUSE Linux Enterprise Server',
+            'identifier': 'SLES',
+            'former_identifier': 'SLES',
+            'version': '15.4',
+            'release_type': None,
+            'release_stage': 'released',
+            'arch': 'x86_64',
+            'friendly_name': 'SUSE Linux Enterprise Server 15 SP4 x86_64',
+            'product_class': '30',
+            'extensions': [
+                {
+                    'id': 23,
+                    'name': 'SUSE Linux Enterprise Server LTSS Foo',
+                    'identifier': 'SLES-LTSS-FOO',
+                    'former_identifier': 'SLES-LTSS-FOO',
+                    'version': '15.4',
+                    'release_type': None,
+                    'release_stage': 'released',
+                    'arch': 'x86_64',
+                    'friendly_name':
+                    'SUSE Linux Enterprise Server LTSS 15 SP4 x86_64',
+                    'product_class': 'SLES15-SP4-LTSS-FOO-X86',
+                    'free': False,
+                    'repositories': [],
+                    'product_type': 'extension',
+                    'extensions': [],
+                    'recommended': False,
+                    'available': True
+                }
+            ]
+        }
+        response.json = json_mock
+        mock_requests_get.return_value = response
+        mock_get_creds.return_value = 'SCC_foo', 'bar'
+        base_product = dedent('''\
+            <?xml version="1.0" encoding="UTF-8"?>
+            <product schemeversion="0">
+              <vendor>SUSE</vendor>
+              <name>SLES</name>
+              <version>15.4</version>
+              <baseversion>15</baseversion>
+              <patchlevel>4</patchlevel>
+              <release>0</release>
+              <endoflife></endoflife>
+              <arch>x86_64</arch></product>''')
+        mock_get_product_tree.return_value = etree.fromstring(
+            base_product[base_product.index('<product'):]
+        )
+        mock_get_register_cmd.return_value = '/usr/sbin/SUSEConnect'
+        mock_has_nvidia_support.return_value = False
+        mock_find_repos.return_value = ['repo_a', 'repo_b']
+        mock_get_repo_url.return_value = (
+            'plugin:/susecloud?credentials=Basesystem_Module_x86_64&'
+            'path=/repo/SUSE/Updates/SLE-Module-Basesystem/15-SP4/x86_64/update/'
+        )
+        findmnt_return = b'{"filesystems": [{"target": "/","source": ' + \
+            b'"/dev/sda3","fstype": "xfs","options": "ro"}]}'
+        mock_exec_subprocess.return_value = findmnt_return, b'', 0
+        mock_os_path_exists.reset_mock()
+        mock_os_path_exists.return_value = True
+        mock_urlparse.return_value = ParseResult(
+            scheme='https', netloc='susecloud.net:443',
+            path='/some/repo', params='',
+            query='highlight=params', fragment='url-parsing'
+        )
+        mock_set_proxy.return_value = False
+        mock_setup_registry.return_value = False
+        with raises(SystemExit) as sys_exit:
+            register_cloud_guest.main(fake_args, Mock())
+            assert sys_exit.value.code == 1

--- a/test/unit/smt_test.py
+++ b/test/unit/smt_test.py
@@ -447,7 +447,7 @@ def test_write_cert_ipv4_only(mock_get_cert):
     mock_get_cert.return_value = 'what a cert'
     smt = SMT(etree.fromstring(smt_data_ipv4))
     with tempfile.TemporaryDirectory() as tmpdirname:
-        smt.write_cert(tmpdirname)
+        smt.write_cert(tmpdirname, Mock())
         certs = glob.glob('%s/*.pem' % tmpdirname)
         assert len(certs) == 1
         assert certs[0] == (


### PR DESCRIPTION
This commit refactors the cleanup code into single responsibility methods for each type of cleanup. The registration client has three areas for the cleanup

1. API delete requests to the SCC/RMT API
2. Cleanup of registration client specific cache data
3. Cleanup of configuration data created and or modified in /etc

The code changes refactors the existing cleanup methods to not intermix the different cleanup types and provides methods to implement cleanup methods properly to the type of cleanup.

As an additional feature a new class named Git is provided which allows to manage the cleanup of type 3 data (etc) in git. This feature can be enabled via the --git option and requires the user to install git beforehand as we cannot force users to install git.

The git feature is handy for debugging and full control over the data that the client really touches when performing the registration. It's possible to switch between git and no git managed data at any time. Customers who are not against git to be present on a server and see the positive side effects to have full control over data changed on the server by a registration client also might find this feature useful.

Last but not least the git feature would solve the still present cleanup bug which prevents credentials files from being cleaned up under certain conditions. As such we still have to create a fix for this bug in the standard/legacy cleanup code. With the refactoring code as part of this PR this task will also become easier because the
cleanup methods are now more clear in structure and processing.

Finally a number of unit tests got updated to be more readable, less fragile and less painful to update in case of code changes. There are still a number of tests that could be improved though.