### PR TITLE
Fix Makefile package target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,10 @@
 buildroot = /
 
-python_version = 3
-python_lookup_name = python$(python_version)
-python = $(shell which $(python_lookup_name))
-
-version := $(shell \
-    $(python) -c \
-    'from cloudregister.registercloudguest import __version__; print(__version__)'\
-)
-
 clean:
 	rm -rf dist
 
-package: clean
+package: clean check test
+	$(eval version := $(shell poetry run python -c 'from cloudregister.registercloudguest import __version__; print(__version__)'))
 	# build the sdist source tarball
 	poetry build --format=sdist
 	# provide rpm source tarball


### PR DESCRIPTION
The Makefile looked up the version information by calling a small python script that imports the version information from source. This required to lookup the python interpreter from the host which can be avoided now that we use poetry for development. This commit moves the creation of the version variable to the target where it is needed and uses "poetry run python" to obtain the version information.