### PR TITLE
Refactor cleanup code

### DIFF
--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -17,11 +17,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Tox
+      - name: Install Poetry
         run: |
           python -m pip install --upgrade pip
           python -m pip install poetry
-      - name: Run flake checks
+      - name: Run checks
         run: make check
         env:
           PY_VER: ${{ matrix.python-version }}

--- a/cloudregister/cloudguest_lic_watcher.py
+++ b/cloudregister/cloudguest_lic_watcher.py
@@ -55,7 +55,7 @@ def maybe_drop_registration(license_type):
         if not utils.uses_rmt_as_scc_proxy():
             log.info(
                 'Detected flavor change to BYOS, clean up registration')
-            utils.clean_all()
+            utils.clean_all_standard()
             utils.exec_subprocess(['systemctl', 'disable', SERVICE_NAME])
 
 
@@ -72,7 +72,7 @@ def maybe_register_system(license_type):
             # The system is registered to the update infrastructure using
             # a registration code. Now that the system is PAYG we have to
             # clean up that registration
-            utils.clean_all()
+            utils.clean_all_standard()
             log.info(base_msg.format(
                 status='removed registration to update infra as BYOS')
             )
@@ -80,7 +80,7 @@ def maybe_register_system(license_type):
         if not current_target and utils.is_scc_connected():
             # The system is registered to the SUSE Customer center. Now
             # that the system is PAYG we have to clean up that registration
-            utils.clean_all()
+            utils.clean_all_standard()
             log.info(base_msg.format(
                 status='removed registration to SCC as BYOS')
             )

--- a/cloudregister/cloudguest_repo_service.py
+++ b/cloudregister/cloudguest_repo_service.py
@@ -24,7 +24,10 @@ from lxml import etree
 from requests.auth import HTTPBasicAuth
 
 from cloudregister.logger import Logger
-from cloudregister.defaults import LOG_FILE
+from cloudregister.defaults import (
+    LOG_FILE,
+    REGISTRATION_DATA_DIR
+)
 import cloudregister.registerutils as utils
 
 log_instance = Logger()
@@ -34,7 +37,7 @@ log = Logger.get_logger()
 
 def print_repo_data(update_server, activation, available_repos):
     """Print repository data from product activation info."""
-    service_revert_file = os.path.join(utils.REGISTRATION_DATA_DIR, 'installservice')
+    service_revert_file = os.path.join(REGISTRATION_DATA_DIR, 'installservice')
     service_info = activation.get('service')
     service_name = service_info.get('name')
     service_url = service_info.get('url')

--- a/cloudregister/createregioninfo.py
+++ b/cloudregister/createregioninfo.py
@@ -22,11 +22,14 @@ import os
 import sys
 
 import cloudregister.registerutils as utils
+from cloudregister.defaults import (
+    FRAMEWORK_IDENTIFIER
+)
 
 
 def app():
     region_info_path = os.path.join(
-        utils.get_state_dir(), utils.FRAMEWORK_IDENTIFIER
+        utils.get_state_dir(), FRAMEWORK_IDENTIFIER
     )
 
     if os.path.exists(region_info_path):

--- a/cloudregister/defaults.py
+++ b/cloudregister/defaults.py
@@ -13,4 +13,29 @@
 #
 #
 LOG_FILE = '/var/log/cloudregister'
+
+# etc content
 ZYPP_SERVICES = '/etc/zypp/services.d'
+HOSTSFILE_PATH = '/etc/hosts'
+REGISTRY_CREDENTIALS_PATH = '/etc/containers/config.json'
+PROFILE_LOCAL_PATH = '/etc/profile.local'
+REGISTRIES_CONF_PATH = '/etc/containers/registries.conf'
+DOCKER_CONFIG_PATH = '/etc/docker/daemon.json'
+SUMA_REGISTRY_CONF_PATH = '/etc/uyuni/uyuni-tools.yaml'
+BASE_PRODUCT_PATH = '/etc/products.d/baseproduct'
+ZYPP_CREDENTIALS_PATH = '/etc/zypp/credentials.d'
+
+# var content
+OLD_REGISTRATION_DATA_DIR = '/var/lib/cloudregister'
+REGISTRATION_DATA_DIR = '/var/cache/cloudregister'
+
+# constants
+AVAILABLE_SMT_SERVER_DATA_FILE_NAME = 'availableSMTInfo_%s.obj'
+BASE_CREDENTIALS_NAME = 'SCCcredentials'
+FRAMEWORK_IDENTIFIER = 'framework_info'
+NEW_REGISTRATION_MARKER = 'newregistration'
+REGISTRATION_COMPLETED_MARKER = 'registrationcompleted'
+REGISTERED_SMT_SERVER_DATA_FILE_NAME = 'currentSMTInfo.obj'
+RMT_AS_SCC_PROXY_MARKER = 'rmt_is_scc_proxy'
+SUSE_REGISTRY = 'registry.suse.com'
+REGSHARING_SYNC_TIME = 30

--- a/cloudregister/registerutils.py
+++ b/cloudregister/registerutils.py
@@ -40,25 +40,26 @@ from requests.auth import HTTPBasicAuth
 from cloudregister.logger import Logger
 from cloudregister import smt
 
-AVAILABLE_SMT_SERVER_DATA_FILE_NAME = 'availableSMTInfo_%s.obj'
-BASE_CREDENTIALS_NAME = 'SCCcredentials'
-FRAMEWORK_IDENTIFIER = 'framework_info'
-HOSTSFILE_PATH = '/etc/hosts'
-NEW_REGISTRATION_MARKER = 'newregistration'
-REGISTRATION_COMPLETED_MARKER = 'registrationcompleted'
-OLD_REGISTRATION_DATA_DIR = '/var/lib/cloudregister'
-REGISTRATION_DATA_DIR = '/var/cache/cloudregister'
-REGISTERED_SMT_SERVER_DATA_FILE_NAME = 'currentSMTInfo.obj'
-RMT_AS_SCC_PROXY_MARKER = 'rmt_is_scc_proxy'
-REGISTRY_CREDENTIALS_PATH = '/etc/containers/config.json'
-PROFILE_LOCAL_PATH = '/etc/profile.local'
-REGISTRIES_CONF_PATH = '/etc/containers/registries.conf'
-DOCKER_CONFIG_PATH = '/etc/docker/daemon.json'
-SUMA_REGISTRY_CONF_PATH = '/etc/uyuni/uyuni-tools.yaml'
-BASE_PRODUCT_PATH = '/etc/products.d/baseproduct'
-SUSE_REGISTRY = 'registry.suse.com'
-REGSHARING_SYNC_TIME = 30
-ZYPP_CREDENTIALS_PATH = '/etc/zypp/credentials.d'
+from cloudregister.defaults import (
+    AVAILABLE_SMT_SERVER_DATA_FILE_NAME,
+    BASE_CREDENTIALS_NAME,
+    FRAMEWORK_IDENTIFIER,
+    HOSTSFILE_PATH,
+    NEW_REGISTRATION_MARKER,
+    REGISTRATION_COMPLETED_MARKER,
+    REGISTRATION_DATA_DIR,
+    REGISTERED_SMT_SERVER_DATA_FILE_NAME,
+    RMT_AS_SCC_PROXY_MARKER,
+    REGISTRY_CREDENTIALS_PATH,
+    PROFILE_LOCAL_PATH,
+    REGISTRIES_CONF_PATH,
+    DOCKER_CONFIG_PATH,
+    SUMA_REGISTRY_CONF_PATH,
+    BASE_PRODUCT_PATH,
+    SUSE_REGISTRY,
+    REGSHARING_SYNC_TIME,
+    ZYPP_CREDENTIALS_PATH
+)
 
 requests.packages.urllib3.disable_warnings(
     requests.packages.urllib3.exceptions.InsecureRequestWarning
@@ -112,20 +113,34 @@ def add_region_server_args_to_URL(api, cfg):
 
 
 # ----------------------------------------------------------------------------
-def clean_all():
-    """Clean up any registration artifacts"""
-    try:
-        clean_non_free_extensions()
-    except Exception as err:
-        log.info('Could not check the system product data: {}'.format(err))
+def clean_all_standard():
+    """
+    Clean up any registration artifacts
 
+    This is the standard method which cleans up registration data
+    """
+    # Clean registrations via API requests
+    deregister_non_free_extensions()
+    deregister_from_update_infrastructure()
+    deregister_from_SCC()
+
+    # Clean all data from etc
+    clean_repo_artifacts()
     clean_registry_setup()
-    remove_registration_data()
+    clean_hosts_file()
+
+    # Clean all cache data from /var/cache
+    clean_cache()
+
+
+# ----------------------------------------------------------------------------
+def clean_cache():
     clean_smt_cache()
+    clear_rmt_as_scc_proxy_flag()
     clear_new_registration_flag()
     clean_framework_identifier()
-    clean_hosts_file()
     clear_registration_completed_flag()
+    clean_registered_smt_data_file()
 
 
 # ----------------------------------------------------------------------------
@@ -168,11 +183,43 @@ def clean_hosts_file(domain_name=None):
 
 
 # ----------------------------------------------------------------------------
+def clean_repo_artifacts():
+    """Remove the artifacts related to repository handling for a registration
+    """
+    repo_server_names = []
+    # Lookup SCC connected...
+    if is_scc_connected():
+        repo_server_names.append('suse.com')
+
+    # Lookup update infrastructure connected...
+    smt_data_file = _get_registered_smt_file_path()
+    if os.path.exists(smt_data_file):
+        smt = get_smt_from_store(smt_data_file)
+        repo_server_names.append(smt.get_FQDN())
+
+    if repo_server_names:
+        _remove_credentials(repo_server_names)
+        _remove_repos(repo_server_names)
+        _remove_service(repo_server_names)
+
+    if os.path.exists('/etc/SUSEConnect'):
+        os.unlink('/etc/SUSEConnect')
+
+
+# ----------------------------------------------------------------------------
 def clean_framework_identifier():
     """Remove the framework identification data"""
     framework_file_path = os.sep.join([get_state_dir(), FRAMEWORK_IDENTIFIER])
     if os.path.exists(framework_file_path):
         os.unlink(framework_file_path)
+
+
+# ----------------------------------------------------------------------------
+def clean_registered_smt_data_file():
+    """Remove the registered SMT data cache file"""
+    smt_data_file = _get_registered_smt_file_path()
+    if os.path.exists(smt_data_file):
+        os.unlink(smt_data_file)
 
 
 # ----------------------------------------------------------------------------
@@ -211,35 +258,39 @@ def is_product_removable(triplet):
 
 
 # ----------------------------------------------------------------------------
-def clean_non_free_extensions():
-    """Remove/uninstall non free extensions from the system."""
-    extensions = get_extensions()
-    installed_products = get_installed_products()
+def deregister_non_free_extensions():
+    """deregister non free extensions from the system."""
+    try:
+        extensions = get_extensions()
+        installed_products = get_installed_products()
 
-    for extension in extensions:
-        # The following not free condition checks on
-        # the access capability of the extension
-        # This is a server side capability
-        if not extension.get('free', True):
-            triplet = get_product_triplet(extension)
-            triplet = '{name}/{version}/{arch}'.format(
-                name=triplet.name,
-                version=triplet.version,
-                arch=triplet.arch
-            )
-            if triplet in installed_products and is_product_removable(triplet):
-                reg_prod = register_product(
-                    registration_target=get_current_smt(),
-                    product=triplet,
-                    de_register=True
+        for extension in extensions:
+            # The following not free condition checks on
+            # the access capability of the extension
+            # This is a server side capability
+            if not extension.get('free', True):
+                triplet = get_product_triplet(extension)
+                triplet = '{name}/{version}/{arch}'.format(
+                    name=triplet.name,
+                    version=triplet.version,
+                    arch=triplet.arch
                 )
-                msg = 'Non free extension {} '.format(triplet)
-                if reg_prod.returncode:
-                    msg += 'failed to be removed'
-                else:
-                    msg += 'removed'
-
-                log.info(msg)
+                if triplet in installed_products and is_product_removable(triplet):
+                    reg_prod = register_product(
+                        registration_target=get_current_smt(),
+                        product=triplet,
+                        de_register=True
+                    )
+                    msg = 'Non free extension {} '.format(triplet)
+                    if reg_prod.returncode:
+                        msg += 'failed to be removed'
+                    else:
+                        msg += 'removed'
+                    log.info(msg)
+    except Exception as issue:
+        log.info(
+            'Deregister non free extensions failed with: {}'.format(issue)
+        )
 
 
 # ----------------------------------------------------------------------------
@@ -462,10 +513,13 @@ def register_product(
         log_information = log_information.replace(regcode, 'XXXX')
 
     log.info('Registration: {0}'.format(log_information))
+
+    # perform registration
     output, error, returncode = exec_subprocess(cmd, tolog=False)
     suseconnect_type = namedtuple(
         'suseconnect_type', ['returncode', 'output', 'error']
     )
+
     return suseconnect_type(
         returncode=returncode,
         output=output.decode(),
@@ -2140,9 +2194,10 @@ def get_domain_name_from_region_server():
 
 
 # ----------------------------------------------------------------------------
-def remove_registration_data():
-    """Reset the instance to an unregistered state"""
-    clear_rmt_as_scc_proxy_flag()
+def deregister_from_update_infrastructure():
+    """
+    Send delete request to registration server
+    """
     smt_data_file = _get_registered_smt_file_path()
     user, password = get_credentials(
         os.sep.join([ZYPP_CREDENTIALS_PATH, BASE_CREDENTIALS_NAME])
@@ -2151,8 +2206,6 @@ def remove_registration_data():
         if not is_new_registration():
             log.info('No credentials, nothing to do server side')
         return
-
-    server_names = []
     auth_creds = HTTPBasicAuth(user, password)
     if os.path.exists(smt_data_file):
         smt = get_smt_from_store(smt_data_file)
@@ -2168,15 +2221,25 @@ def remove_registration_data():
                     'System successfully removed from update infrastructure'
                 )
             else:
-                rmt_check_msg = 'System unknown to update infrastructure, '
-                rmt_check_msg += 'continue with local changes'
+                rmt_check_msg = 'System unknown to update infrastructure'
                 log.info(rmt_check_msg)
-        except requests.exceptions.RequestException as e:
-            log.warning('Unable to remove client registration from server')
-            log.warning(e)
-            log.info('Continue with local artifact removal')
-        server_names.append(server_name)
-        os.unlink(smt_data_file)
+        except requests.exceptions.RequestException as issue:
+            log.warning(
+                'Unable to remove client registration from server: {}'.format(issue)
+            )
+        return server_name
+
+
+# ----------------------------------------------------------------------------
+def deregister_from_SCC():
+    user, password = get_credentials(
+        os.sep.join([ZYPP_CREDENTIALS_PATH, BASE_CREDENTIALS_NAME])
+    )
+    if not user:
+        if not is_new_registration():
+            log.info('No credentials, nothing to do server side')
+        return
+    auth_creds = HTTPBasicAuth(user, password)
     if is_scc_connected():
         log.info('Removing system from SCC')
         try:
@@ -2192,7 +2255,7 @@ def remove_registration_data():
                 scc_check_msg += 'System user name: "%s". '
                 scc_check_msg += 'Local registration artifacts removed.'
                 log.info(scc_check_msg % user)
-        except requests.exceptions.RequestException as e:
+        except requests.exceptions.RequestException as issue:
             scc_except_msg = 'Unable to remove client registration from SCC. '
             scc_except_msg += 'The system is most likely still tracked against'
             scc_except_msg += ' your subscription. Please inform your SCC '
@@ -2200,14 +2263,8 @@ def remove_registration_data():
             scc_except_msg += 'should be removed from SCC. Registration '
             scc_except_msg += 'artifacts removed locally.'
             log.error(scc_except_msg % user)
-            log.warning(e)
-
-        server_names.append('suse.com')
-    else:
-        log.info('No current registration server set.')
-
-    log.info('Removing repository artifacts')
-    _remove_repo_artifacts(server_names)
+            log.warning(issue)
+        return 'suse.com'
 
 
 # ----------------------------------------------------------------------------
@@ -2574,18 +2631,6 @@ def _remove_credentials(smt_server_names):
             os.unlink(system_credential)
 
     return 1
-
-
-# ----------------------------------------------------------------------------
-def _remove_repo_artifacts(repo_server_names):
-    """Remove the artifacts related to repository handling for a registration
-    """
-    _remove_credentials(repo_server_names)
-    _remove_repos(repo_server_names)
-    _remove_service(repo_server_names)
-
-    if os.path.exists('/etc/SUSEConnect'):
-        os.unlink('/etc/SUSEConnect')
 
 
 # ----------------------------------------------------------------------------

--- a/cloudregister/updatesmtcache.py
+++ b/cloudregister/updatesmtcache.py
@@ -19,12 +19,16 @@ import glob
 import os
 
 import cloudregister.registerutils as utils
+from cloudregister.defaults import (
+    OLD_REGISTRATION_DATA_DIR,
+    REGISTRATION_DATA_DIR
+)
 
 from cloudregister import smt
 
 
 def app():
-    if os.path.exists(utils.OLD_REGISTRATION_DATA_DIR):
+    if os.path.exists(OLD_REGISTRATION_DATA_DIR):
         # The case where both new and old location exist cannot happen. This
         # code runs on package update and as such moves the directory.
         #
@@ -32,14 +36,14 @@ def app():
         # split(). We want to make sure we do not create nested dirs.
         os.system(
             'mv {} {}'.format(
-                utils.OLD_REGISTRATION_DATA_DIR,
-                os.sep.join(utils.REGISTRATION_DATA_DIR.split(os.sep)[:-2])
+                OLD_REGISTRATION_DATA_DIR,
+                os.sep.join(REGISTRATION_DATA_DIR.split(os.sep)[:-2])
             )
         )
 
     # Update the server cache with region information introduced in
     # region server 8.1.3
-    cached_server_files = glob.glob('%s/*SMT*' % utils.REGISTRATION_DATA_DIR)
+    cached_server_files = glob.glob('%s/*SMT*' % REGISTRATION_DATA_DIR)
     proxies = None
     if utils.set_proxy():
         proxies = {

--- a/package/fix-for-sles12-disable-registry.patch
+++ b/package/fix-for-sles12-disable-registry.patch
@@ -1,10 +1,10 @@
 diff --git a/cloudregister/registercloudguest.py b/cloudregister/registercloudguest.py
-index 7b9f3f0..d11cde5 100644
+index 398a169..5d345d1 100644
 --- a/cloudregister/registercloudguest.py
 +++ b/cloudregister/registercloudguest.py
-@@ -138,6 +138,8 @@ def setup_registry(registration_target, clean='registry'):
-     clean == all -> cleans repository and registry setup
-     clean == registry -> clean only registry artifacts
+@@ -142,6 +142,8 @@ def setup_registry(registration_target):
+     """
+     Run the registration process for the container registry
      """
 +    # Disabled on SLE12
 +    return None
@@ -12,7 +12,7 @@ index 7b9f3f0..d11cde5 100644
          utils.get_credentials_file(registration_target)
      )
 diff --git a/cloudregister/registerutils.py b/cloudregister/registerutils.py
-index ded03ef..54d7aa5 100644
+index 371d2aa..ee65904 100644
 --- a/cloudregister/registerutils.py
 +++ b/cloudregister/registerutils.py
 @@ -29,7 +29,8 @@ import stat
@@ -25,7 +25,7 @@ index ded03ef..54d7aa5 100644
  import yaml
  
  from collections import namedtuple
-@@ -81,11 +82,12 @@ def add_hosts_entry(smt_server):
+@@ -82,11 +83,12 @@ def add_hosts_entry(smt_server):
          smt_server.get_FQDN(),
          smt_server.get_name()
      )
@@ -43,7 +43,7 @@ index ded03ef..54d7aa5 100644
  
      with open('/etc/hosts', 'a') as hosts_file:
          hosts_file.write(smt_hosts_entry_comment)
-@@ -913,6 +915,8 @@ def set_container_engines_env_vars():
+@@ -967,6 +969,8 @@ def set_container_engines_env_vars():
  
  # ----------------------------------------------------------------------------
  def get_registry_conf_file(container_path, container):
@@ -52,7 +52,7 @@ index ded03ef..54d7aa5 100644
      registries_conf = {}
      try:
          with open(container_path, 'r') as registries_conf_file:
-@@ -959,6 +963,8 @@ def update_bashrc(content, mode):
+@@ -1013,6 +1017,8 @@ def update_bashrc(content, mode):
  # ----------------------------------------------------------------------------
  def clean_registry_setup():
      """Remove the data previously set to make the registry work."""
@@ -61,7 +61,7 @@ index ded03ef..54d7aa5 100644
      smt = get_smt_from_store(_get_registered_smt_file_path())
      private_registry_fqdn = smt.get_registry_FQDN() if smt else ''
      clean_registry_auth(private_registry_fqdn)
-@@ -1229,6 +1235,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
+@@ -1283,6 +1289,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
  # ----------------------------------------------------------------------------
  def write_registries_conf(registries_conf, container_path, container_name):
      """Write registries_conf content to container_path."""

--- a/test/unit/registerutils_test.py
+++ b/test/unit/registerutils_test.py
@@ -34,6 +34,11 @@ from cloudregister.logger import Logger
 
 import cloudregister.registerutils as utils # noqa
 from cloudregister.smt import SMT # noqa
+from cloudregister.defaults import (
+    REGISTRATION_DATA_DIR,
+    ZYPP_CREDENTIALS_PATH,
+    OLD_REGISTRATION_DATA_DIR
+)
 
 test_path = '..'
 data_path = test_path + os.sep + 'data/'
@@ -56,9 +61,9 @@ class TestRegisterUtils:
            should be updated. If this test fails do not modify the test, fix the
            path definition in the code and make sure wherever it is used is
            proper."""
-        _check_dir_path(utils.OLD_REGISTRATION_DATA_DIR)
-        _check_dir_path(utils.REGISTRATION_DATA_DIR)
-        _check_dir_path(utils.ZYPP_CREDENTIALS_PATH)
+        _check_dir_path(OLD_REGISTRATION_DATA_DIR)
+        _check_dir_path(REGISTRATION_DATA_DIR)
+        _check_dir_path(ZYPP_CREDENTIALS_PATH)
 
     def test_file_name_constants(self):
         """Make sure our constants that define file names meet our
@@ -791,7 +796,7 @@ class TestRegisterUtils:
     @patch('cloudregister.registerutils.get_product_tree')
     @patch('cloudregister.registerutils.get_current_smt')
     @patch('cloudregister.registerutils.requests.get')
-    def test_clean_non_free_extensions(
+    def test_deregister_non_free_extensions(
         self,
         mock_requests_get,
         mock_get_current_smt,
@@ -871,7 +876,7 @@ class TestRegisterUtils:
             output='all OK',
             error='stderr'
         )
-        utils.clean_non_free_extensions()
+        utils.deregister_non_free_extensions()
         assert mock_register_product.call_args_list == [
             call(
                 registration_target=smt_server,
@@ -890,7 +895,7 @@ class TestRegisterUtils:
     @patch('cloudregister.registerutils.get_product_tree')
     @patch('cloudregister.registerutils.get_current_smt')
     @patch('cloudregister.registerutils.requests.get')
-    def test_clean_non_free_extensions_should_not_be_removed(
+    def test_deregister_non_free_extensions_should_not_be_removed(
         self,
         mock_requests_get,
         mock_get_current_smt,
@@ -994,7 +999,7 @@ class TestRegisterUtils:
             error='stderr'
         )
         mock_is_suma_instance.return_value = True
-        utils.clean_non_free_extensions()
+        utils.deregister_non_free_extensions()
         assert mock_register_product.call_args_list == [
             call(
                 registration_target=smt_server,
@@ -1006,158 +1011,12 @@ class TestRegisterUtils:
         assert 'No credentials entry for "SCC*"' in self._caplog.text
         assert 'Non free extension SLES-LTSS/15.4/x86_64 removed' in self._caplog.text
 
-    @patch('cloudregister.registerutils.register_product')
-    @patch('cloudregister.registerutils.get_installed_products')
-    @patch('cloudregister.registerutils.get_credentials')
-    @patch('cloudregister.registerutils.get_product_tree')
-    @patch('cloudregister.registerutils.get_current_smt')
-    @patch('cloudregister.registerutils.requests.get')
-    def test_clean_non_free_extensions_failed(
-        self,
-        mock_requests_get,
-        mock_get_current_smt,
-        mock_get_product_tree,
-        mock_get_creds,
-        mock_get_installed_products,
-        mock_register_product
-    ):
-        mock_get_installed_products.return_value = ['SLES-LTSS/15.4/x86_64']
-        response = Response()
-        response.status_code = requests.codes.ok
-        json_mock = Mock()
-        json_mock.return_value = {
-            'id': 2001,
-            'name': 'SUSE Linux Enterprise Server',
-            'identifier': 'SLES',
-            'former_identifier': 'SLES',
-            'version': '15.4',
-            'release_type': None,
-            'release_stage': 'released',
-            'arch': 'x86_64',
-            'friendly_name': 'SUSE Linux Enterprise Server 15 SP4 x86_64',
-            'product_class': '30',
-            'extensions': [
-                {
-                    'id': 23,
-                    'name': 'SUSE Linux Enterprise Server LTSS',
-                    'identifier': 'SLES-LTSS',
-                    'former_identifier': 'SLES-LTSS',
-                    'version': '15.4',
-                    'release_type': None,
-                    'release_stage': 'released',
-                    'arch': 'x86_64',
-                    'friendly_name':
-                    'SUSE Linux Enterprise Server LTSS 15 SP4 x86_64',
-                    'product_class': 'SLES15-SP4-LTSS-X86',
-                    'free': False,
-                    'repositories': [],
-                    'product_type': 'extension',
-                    'extensions': [],
-                    'recommended': False,
-                    'available': True
-                }
-            ]
-        }
-        response.json = json_mock
-        mock_requests_get.return_value = response
-        smt_data_ipv46 = dedent('''\
-            <smtInfo fingerprint="00:11:22:33"
-             SMTserverIP="192.168.1.1"
-             SMTserverIPv6="fc00::1"
-             SMTserverName="fantasy.example.com"
-             SMTregistryName=""
-             region="antarctica-1"/>''')
-        smt_server = SMT(etree.fromstring(smt_data_ipv46))
-        mock_get_current_smt.return_value = smt_server
-        mock_get_creds.return_value = 'SCC_foo', 'bar'
-        base_product = dedent('''\
-            <?xml version="1.0" encoding="UTF-8"?>
-            <product schemeversion="0">
-              <vendor>SUSE</vendor>
-              <name>SLES</name>
-              <version>15.4</version>
-              <baseversion>15</baseversion>
-              <patchlevel>4</patchlevel>
-              <release>0</release>
-              <endoflife></endoflife>
-              <arch>x86_64</arch></product>''')
-        mock_get_product_tree.return_value = etree.fromstring(
-            base_product[base_product.index('<product'):]
-        )
-        prod_reg_type = namedtuple(
-            'prod_reg_type', ['returncode', 'output', 'error']
-        )
-        mock_register_product.return_value = prod_reg_type(
-            returncode=1,
-            output='all OK',
-            error='stderr'
-        )
-        utils.clean_non_free_extensions()
-        assert mock_register_product.call_args_list == [
-            call(
-                registration_target=smt_server,
-                product='SLES-LTSS/15.4/x86_64',
-                de_register=True
-            )
-        ]
-        assert 'No credentials entry for "*fantasy_example_com"' in self._caplog.text
-        assert 'No credentials entry for "SCC*"' in self._caplog.text
-        assert 'Non free extension SLES-LTSS/15.4/x86_64 failed to be removed' in self._caplog.text
-
     @patch('cloudregister.registerutils.os.unlink')
     @patch('cloudregister.registerutils.get_credentials')
     @patch('cloudregister.registerutils.get_product_tree')
     @patch('cloudregister.registerutils.get_current_smt')
     @patch('cloudregister.registerutils.requests.get')
-    def test_clean_non_free_extensions_request_failed(
-        self,
-        mock_requests_get,
-        mock_get_current_smt,
-        mock_get_product_tree,
-        mock_get_creds,
-        mock_os_unlink
-    ):
-        response = Response()
-        response.status_code = requests.codes.forbidden
-        response.reason = 'Because nope'
-        response.content = str(json.dumps('no accessio')).encode()
-        mock_requests_get.return_value = response
-        smt_data_ipv46 = dedent('''\
-            <smtInfo fingerprint="00:11:22:33"
-             SMTserverIP="192.168.1.1"
-             SMTserverIPv6="fc00::1"
-             SMTserverName="fantasy.example.com"
-             SMTregistryName=""
-             region="antarctica-1"/>''')
-        smt_server = SMT(etree.fromstring(smt_data_ipv46))
-        mock_get_current_smt.return_value = smt_server
-        mock_get_creds.return_value = 'SCC_foo', 'bar'
-        base_product = dedent('''\
-            <?xml version="1.0" encoding="UTF-8"?>
-            <product schemeversion="0">
-              <vendor>SUSE</vendor>
-              <name>SLES</name>
-              <version>15.4</version>
-              <baseversion>15</baseversion>
-              <patchlevel>4</patchlevel>
-              <release>0</release>
-              <endoflife></endoflife>
-              <arch>x86_64</arch></product>''')
-        mock_get_product_tree.return_value = etree.fromstring(
-            base_product[base_product.index('<product'):]
-        )
-        with raises(Exception):
-            utils.clean_non_free_extensions()
-        assert mock_os_unlink.mock_calls == []
-        assert 'No matching credentials file found' in self._caplog.text
-        assert 'Unable to obtain product information' in self._caplog.text
-
-    @patch('cloudregister.registerutils.os.unlink')
-    @patch('cloudregister.registerutils.get_credentials')
-    @patch('cloudregister.registerutils.get_product_tree')
-    @patch('cloudregister.registerutils.get_current_smt')
-    @patch('cloudregister.registerutils.requests.get')
-    def test_clean_non_free_extensions_no_credentials(
+    def test_deregister_non_free_extensions_no_credentials(
         self,
         mock_requests_get,
         mock_get_current_smt,
@@ -1166,7 +1025,7 @@ class TestRegisterUtils:
         mock_os_unlink
     ):
         mock_get_current_smt.return_value = None
-        utils.clean_non_free_extensions()
+        utils.deregister_non_free_extensions()
         assert mock_os_unlink.mock_calls == []
 
     @patch('cloudregister.registerutils.get_register_cmd')
@@ -2612,7 +2471,11 @@ class TestRegisterUtils:
         assert utils.is_registered('some_smt_server') is True
 
     @patch('cloudregister.registerutils._get_service_plugins')
-    def test_has_services_service_no_service(self, mock_get_service_plugins):
+    @patch('glob.glob')
+    def test_has_services_service_no_service(
+        self, mock_glob, mock_get_service_plugins
+    ):
+        mock_glob.return_value = []
         mock_get_service_plugins.return_value = None
         assert utils.has_services('foo') is False
 
@@ -2867,181 +2730,6 @@ class TestRegisterUtils:
         region_smt_data = etree.fromstring(smt_xml)
         mock_fetch_smt_data.return_value = region_smt_data
         assert utils.get_domain_name_from_region_server() == 'susecloud.net'
-
-    @patch('cloudregister.registerutils.get_domain_name_from_region_server')
-    @patch('cloudregister.registerutils.get_credentials')
-    @patch('cloudregister.registerutils._get_registered_smt_file_path')
-    def test_remove_registration_data_no_user(
-        self,
-        mock_get_registered_smt_file_path,
-        mock_get_creds,
-        mock_get_domain_name_from_region_server
-    ):
-        mock_get_creds.return_value = None, None
-        mock_get_domain_name_from_region_server.return_value = 'foo'
-        assert utils.remove_registration_data() is None
-        assert 'No credentials, nothing to do server side' in self._caplog.text
-
-    @patch('cloudregister.registerutils._remove_credentials')
-    @patch('cloudregister.registerutils.get_domain_name_from_region_server')
-    @patch('cloudregister.registerutils.os.path.exists')
-    @patch('cloudregister.registerutils.is_scc_connected')
-    @patch('cloudregister.registerutils.get_credentials')
-    @patch('cloudregister.registerutils._get_registered_smt_file_path')
-    def test_remove_registration_data_no_registration(
-        self,
-        mock_get_registered_smt_file_path,
-        mock_get_creds,
-        mock_is_scc_connected,
-        mock_os_path_exists,
-        mock_get_domain_name_from_region_server,
-        mock_remove_credentials
-    ):
-        mock_get_creds.return_value = 'foo', 'bar'
-        mock_is_scc_connected.return_value = False
-        mock_os_path_exists.return_value = False
-        mock_get_domain_name_from_region_server.return_value = 'foo'
-        assert utils.remove_registration_data() is None
-        assert 'No current registration server set.' in self._caplog.text
-        mock_remove_credentials.assert_called_once_with([])
-
-    @patch('cloudregister.registerutils._remove_credentials')
-    @patch('cloudregister.registerutils.is_scc_connected')
-    @patch('cloudregister.registerutils.os.unlink')
-    @patch('cloudregister.registerutils._remove_repo_artifacts')
-    @patch('cloudregister.registerutils.clean_hosts_file')
-    @patch('cloudregister.registerutils.requests.delete')
-    @patch('cloudregister.registerutils.get_smt_from_store')
-    @patch('cloudregister.registerutils.os.path.exists')
-    @patch('cloudregister.registerutils.HTTPBasicAuth')
-    @patch('cloudregister.registerutils.get_credentials')
-    @patch('cloudregister.registerutils._get_registered_smt_file_path')
-    def test_remove_registration_data(
-        self,
-        mock_get_registered_smt_file_path,
-        mock_get_creds,
-        mock_http_basic_auth,
-        mock_os_path_exists,
-        mock_get_smt_from_store,
-        mock_request_delete,
-        mock_clean_hosts_file,
-        mock_remove_repo_artifacts,
-        mock_os_unlink,
-        mock_is_scc_connected,
-        mock_remove_credentials
-    ):
-        mock_get_creds.return_value = 'foo', 'bar'
-        smt_data_ipv46 = dedent('''\
-            <smtInfo fingerprint="00:11:22:33"
-             SMTserverIP="192.168.1.1"
-             SMTserverIPv6="fc00::1"
-             SMTserverName="smt-foo.susecloud.net"
-             SMTregistryName="registry-foo.susecloud.net"
-             region="antarctica-1"/>''')
-        smt_server = SMT(etree.fromstring(smt_data_ipv46))
-        mock_get_smt_from_store.return_value = smt_server
-        mock_os_path_exists.return_value = True
-        mock_http_basic_auth.return_value = 'http basic auth'
-        response = Response()
-        response.status_code = 204
-        mock_request_delete.return_value = response
-        mock_is_scc_connected.return_value = True
-        assert utils.remove_registration_data() is None
-        assert "Clean current registration server: ('192.168.1.1', 'fc00::1')" in self._caplog.text
-        assert 'System successfully removed from update infrastructure' in self._caplog.text
-        assert 'System successfully removed from SCC' in self._caplog.text
-        assert 'Removing repository artifacts' in self._caplog.text
-
-    @patch('cloudregister.registerutils._remove_credentials')
-    @patch('cloudregister.registerutils.is_scc_connected')
-    @patch('cloudregister.registerutils.os.unlink')
-    @patch('cloudregister.registerutils._remove_repo_artifacts')
-    @patch('cloudregister.registerutils.clean_hosts_file')
-    @patch('cloudregister.registerutils.requests.delete')
-    @patch('cloudregister.registerutils.get_smt_from_store')
-    @patch('cloudregister.registerutils.os.path.exists')
-    @patch('cloudregister.registerutils.HTTPBasicAuth')
-    @patch('cloudregister.registerutils.get_credentials')
-    @patch('cloudregister.registerutils._get_registered_smt_file_path')
-    def test_remove_registration_data_request_not_OK(
-        self,
-        mock_get_registered_smt_file_path,
-        mock_get_creds,
-        mock_http_basic_auth,
-        mock_os_path_exists,
-        mock_get_smt_from_store,
-        mock_request_delete,
-        mock_clean_hosts_file,
-        mock_remove_repo_artifacts,
-        mock_os_unlink,
-        mock_is_scc_connected,
-        mock_remove_credentials
-    ):
-        mock_get_creds.return_value = 'foo', 'bar'
-        smt_data_ipv46 = dedent('''\
-            <smtInfo fingerprint="00:11:22:33"
-             SMTserverIP="192.168.1.1"
-             SMTserverIPv6="fc00::1"
-             SMTserverName="smt-foo.susecloud.net"
-             SMTregistryName="registry-foo.susecloud.net"
-             region="antarctica-1"/>''')
-        smt_server = SMT(etree.fromstring(smt_data_ipv46))
-        mock_get_smt_from_store.return_value = smt_server
-        mock_os_path_exists.return_value = True
-        mock_http_basic_auth.return_value = 'http basic auth'
-        response = Response()
-        response.status_code = 504
-        mock_request_delete.return_value = response
-        mock_is_scc_connected.return_value = True
-        assert utils.remove_registration_data() is None
-        assert 'System unknown to update infrastructure' in self._caplog.text
-        assert 'System not found in SCC. The system may still be tracked' in self._caplog.text
-        assert 'Removing repository artifacts' in self._caplog.text
-
-    @patch('cloudregister.registerutils._remove_credentials')
-    @patch('cloudregister.registerutils.is_scc_connected')
-    @patch('cloudregister.registerutils.os.unlink')
-    @patch('cloudregister.registerutils._remove_repo_artifacts')
-    @patch('cloudregister.registerutils.clean_hosts_file')
-    @patch('cloudregister.registerutils.requests.delete')
-    @patch('cloudregister.registerutils.get_smt_from_store')
-    @patch('cloudregister.registerutils.os.path.exists')
-    @patch('cloudregister.registerutils.HTTPBasicAuth')
-    @patch('cloudregister.registerutils.get_credentials')
-    @patch('cloudregister.registerutils._get_registered_smt_file_path')
-    def test_remove_registration_data_request_exception(
-        self,
-        mock_get_registered_smt_file_path,
-        mock_get_creds,
-        mock_http_basic_auth,
-        mock_os_path_exists,
-        mock_get_smt_from_store,
-        mock_request_delete,
-        mock_clean_hosts_file,
-        mock_remove_repo_artifacts,
-        mock_os_unlink,
-        mock_is_scc_connected,
-        mock_remove_credentials
-    ):
-        mock_get_creds.return_value = 'foo', 'bar'
-        smt_data_ipv46 = dedent('''\
-            <smtInfo fingerprint="00:11:22:33"
-             SMTserverIP="192.168.1.1"
-             SMTserverIPv6="fc00::1"
-             SMTserverName="smt-foo.susecloud.net"
-             SMTregistryName="registry-foo.susecloud.net"
-             region="antarctica-1"/>''')
-        smt_server = SMT(etree.fromstring(smt_data_ipv46))
-        mock_get_smt_from_store.return_value = smt_server
-        mock_os_path_exists.return_value = True
-        mock_http_basic_auth.return_value = 'http basic auth'
-        response = Response()
-        response.status_code = 504
-        exception = requests.exceptions.RequestException('foo')
-        mock_request_delete.side_effect = exception
-        mock_is_scc_connected.return_value = True
-        assert utils.remove_registration_data() is None
-        assert 'Unable to remove client registration from SCC. ' in self._caplog.text
 
     @patch('cloudregister.registerutils.add_hosts_entry')
     @patch('cloudregister.registerutils.clean_hosts_file')
@@ -3506,23 +3194,6 @@ class TestRegisterUtils:
         mock_os_unlink.assert_called_once_with(
             '/etc/zypp/credentials.d/SCCcredentials'
         )
-
-    @patch('cloudregister.registerutils.os.unlink')
-    @patch('cloudregister.registerutils.os.path.exists')
-    @patch('cloudregister.registerutils._remove_service')
-    @patch('cloudregister.registerutils._remove_repos')
-    def test_remove_artifacts(
-        self,
-        mock_remove_repos,
-        mock_remove_service,
-        mock_os_path_exists,
-        mock_os_unlink
-    ):
-        mock_os_path_exists.return_value = True
-        assert utils._remove_repo_artifacts(['foo']) is None
-        mock_remove_repos.assert_called_once_with(['foo'])
-        mock_remove_service.assert_called_once_with(['foo'])
-        mock_os_path_exists.assert_called_once_with('/etc/SUSEConnect')
 
     @patch('cloudregister.registerutils.glob.glob')
     @patch('cloudregister.registerutils._get_referenced_credentials')
@@ -4960,6 +4631,229 @@ export DOCKER_CONFIG=/etc/containers
         assert utils._matches_susecloud(
             ['foo', 'registry.susecloud.net', 'registry-azure.susecloud.net']
         ) == 'registry-azure.susecloud.net'
+
+    @patch('cloudregister.registerutils.deregister_non_free_extensions')
+    @patch('cloudregister.registerutils.deregister_from_update_infrastructure')
+    @patch('cloudregister.registerutils.deregister_from_SCC')
+    @patch('cloudregister.registerutils.clean_repo_artifacts')
+    @patch('cloudregister.registerutils.clean_registry_setup')
+    @patch('cloudregister.registerutils.clean_hosts_file')
+    @patch('cloudregister.registerutils.clean_cache')
+    def test_clean_all_standard(
+        self,
+        mock_clean_cache,
+        mock_clean_hosts_file,
+        mock_clean_registry_setup,
+        mock_clean_repo_artifacts,
+        mock_deregister_from_SCC,
+        mock_deregister_from_update_infrastructure,
+        mock_deregister_non_free_extensions
+    ):
+        utils.clean_all_standard()
+        mock_deregister_non_free_extensions.assert_called_once_with()
+        mock_deregister_from_update_infrastructure.assert_called_once_with()
+        mock_clean_cache.assert_called_once_with()
+        mock_clean_hosts_file.assert_called_once_with()
+        mock_clean_registry_setup.assert_called_once_with()
+        mock_clean_repo_artifacts.assert_called_once_with()
+        mock_deregister_from_SCC.assert_called_once_with()
+
+    @patch('cloudregister.registerutils.get_domain_name_from_region_server')
+    def test_clean_hosts_file_no_domain_set(
+        self, mock_get_domain_name_from_region_server
+    ):
+        with patch('builtins.open', create=True):
+            utils.clean_hosts_file()
+            mock_get_domain_name_from_region_server.assert_called_once_with()
+
+    @patch('os.path.exists')
+    @patch('os.unlink')
+    @patch('cloudregister.registerutils.is_scc_connected')
+    @patch('cloudregister.registerutils._remove_credentials')
+    @patch('cloudregister.registerutils._remove_repos')
+    @patch('cloudregister.registerutils._remove_service')
+    @patch('cloudregister.registerutils.get_smt_from_store')
+    def test_clean_repo_artifacts(
+        self,
+        mock_get_smt_from_store,
+        mock_remove_service,
+        mock_remove_repos,
+        mock_remove_credentials,
+        mock_is_scc_connected,
+        mock_os_unlink,
+        mock_os_path_exists
+    ):
+        smt = Mock()
+        smt.get_FQDN.return_value = 'some_FQDN'
+        mock_is_scc_connected.return_value = True
+        mock_os_path_exists.return_value = True
+        mock_get_smt_from_store.return_value = smt
+        utils.clean_repo_artifacts()
+        mock_remove_service.assert_called_once_with(
+            ['suse.com', 'some_FQDN']
+        )
+        mock_remove_repos.assert_called_once_with(
+            ['suse.com', 'some_FQDN']
+        )
+        mock_remove_credentials.assert_called_once_with(
+            ['suse.com', 'some_FQDN']
+        )
+
+    @patch('os.path.exists')
+    @patch('os.unlink')
+    def test_clean_registered_smt_data_file(
+        self, mock_os_unlink, mock_os_path_exists
+    ):
+        mock_os_path_exists.return_value = True
+        utils.clean_registered_smt_data_file()
+        mock_os_unlink.assert_called_once_with(
+            '/var/cache/cloudregister/currentSMTInfo.obj'
+        )
+
+    @patch('cloudregister.registerutils.get_extensions')
+    def test_deregister_non_free_extensions_failed(self, mock_get_extensions):
+        mock_get_extensions.side_effect = Exception
+        utils.deregister_non_free_extensions()
+        assert 'Deregister non free extensions failed with' in \
+            self._caplog.text
+
+    @patch('cloudregister.registerutils.get_extensions')
+    @patch('cloudregister.registerutils.get_installed_products')
+    @patch('cloudregister.registerutils.get_product_triplet')
+    @patch('cloudregister.registerutils.is_product_removable')
+    @patch('cloudregister.registerutils.register_product')
+    def test_deregister_non_free_extensions_failed_to_remove_product(
+        self,
+        mock_register_product,
+        mock_is_product_removable,
+        mock_get_product_triplet,
+        mock_get_installed_products,
+        mock_get_extensions
+    ):
+        product_type = namedtuple(
+            'product_type', ['name', 'version', 'arch']
+        )
+        extension = Mock()
+        extension.get.return_value = False
+        reg_prod = Mock()
+        reg_prod.returncode = 1
+        mock_register_product.return_value = reg_prod
+        mock_get_extensions.return_value = [extension]
+        mock_is_product_removable.return_value = True
+        mock_get_installed_products.return_value = 'some/some/some'
+        mock_get_product_triplet.return_value = product_type(
+            name='some', version='some', arch='some'
+        )
+        utils.deregister_non_free_extensions()
+        assert 'Non free extension some/some/some failed to be removed' in \
+            self._caplog.text
+
+    @patch('cloudregister.registerutils.get_product_triplet')
+    @patch('cloudregister.registerutils.get_product_tree')
+    @patch('cloudregister.registerutils.get_credentials')
+    @patch('cloudregister.registerutils.HTTPBasicAuth')
+    @patch('cloudregister.registerutils.requests.get')
+    def test_get_product_data_request_not_ok(
+        self,
+        mock_requests_get,
+        mock_HTTPBasicAuth,
+        mock_get_credentials,
+        mock_get_product_tree,
+        mock_get_product_triplet
+    ):
+        request = Mock()
+        request.status_code = 500
+        smt = Mock()
+        smt.get_FQDN.return_value = 'some_FQDN'
+        smt.get_ipv4.return_value = 'ipv4'
+        smt.get_ipv6.return_value = 'ipv6'
+        mock_get_credentials.return_value = ('user', 'pass')
+        product_type = namedtuple(
+            'product_type', ['name', 'version', 'arch']
+        )
+        mock_get_product_triplet.return_value = product_type(
+            name='some', version='some', arch='some'
+        )
+        mock_requests_get.return_value = request
+        with raises(Exception):
+            utils.get_product_data(registration_target=smt)
+        assert 'Unable to obtain product information from server' in \
+            self._caplog.text
+
+    @patch('cloudregister.registerutils.get_credentials')
+    @patch('cloudregister.registerutils.HTTPBasicAuth')
+    @patch('cloudregister.registerutils.get_smt_from_store')
+    @patch('cloudregister.registerutils.requests.delete')
+    @patch('os.path.exists')
+    def test_deregister_from_update_infrastructure(
+        self,
+        mock_os_path_exists,
+        mock_requests_delete,
+        mock_get_smt_from_store,
+        mock_HTTPBasicAuth,
+        mock_get_credentials
+    ):
+        smt = Mock()
+        smt.get_FQDN.return_value = 'some_FQDN'
+        smt.get_ipv4.return_value = 'ipv4'
+        smt.get_ipv6.return_value = 'ipv6'
+        request = Mock()
+        mock_requests_delete.return_value = request
+        mock_get_smt_from_store.return_value = smt
+        mock_get_credentials.return_value = ('user', 'pass')
+        mock_os_path_exists.return_value = True
+
+        # test 204 = success return code
+        request.status_code = 204
+        utils.deregister_from_update_infrastructure()
+        assert 'System successfully removed from update infrastructure' in \
+            self._caplog.text
+
+        # test error request
+        request.status_code = 500
+        utils.deregister_from_update_infrastructure()
+        assert 'System unknown to update infrastructure' in \
+            self._caplog.text
+
+        # test exception
+        mock_requests_delete.side_effect = requests.exceptions.RequestException
+        utils.deregister_from_update_infrastructure()
+        assert 'Unable to remove client registration from server' in \
+            self._caplog.text
+
+    @patch('cloudregister.registerutils.HTTPBasicAuth')
+    @patch('cloudregister.registerutils.get_credentials')
+    @patch('cloudregister.registerutils.is_scc_connected')
+    @patch('cloudregister.registerutils.requests.delete')
+    def test_deregister_from_SCC(
+        self,
+        mock_requests_delete,
+        mock_is_scc_connected,
+        mock_get_credentials,
+        mock_HTTPBasicAuth
+    ):
+        request = Mock()
+        mock_requests_delete.return_value = request
+        mock_is_scc_connected.return_value = True
+        mock_get_credentials.return_value = ('user', 'pass')
+
+        # test 204 = success return code
+        request.status_code = 204
+        utils.deregister_from_SCC()
+        assert 'System successfully removed from SCC' in \
+            self._caplog.text
+
+        # test error request
+        request.status_code = 500
+        utils.deregister_from_SCC()
+        assert 'System not found in SCC' in \
+            self._caplog.text
+
+        # test exception
+        mock_requests_delete.side_effect = requests.exceptions.RequestException
+        utils.deregister_from_SCC()
+        assert 'Unable to remove client registration from SCC' in \
+            self._caplog.text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
This commit refactors the cleanup code into single responsibility methods for each type of cleanup. The registration client has three areas for the cleanup

1. API delete requests to the SCC/RMT API
2. Cleanup of registration client specific cache data
3. Cleanup of configuration data created and or modified in /etc

The code changes refactors the existing cleanup methods to not intermix the different cleanup types and provides methods to implement cleanup methods properly to the type of cleanup.