### PR TITLE
Add new Git class for content management

### DIFF
--- a/cloudregister/defaults.py
+++ b/cloudregister/defaults.py
@@ -12,6 +12,8 @@
 # License along with this library.
 #
 #
+import os
+
 LOG_FILE = '/var/log/cloudregister'
 
 # etc content
@@ -52,3 +54,25 @@ SERVER_GENERAL_ERROR = 67
 SERVER_RESPONSE_ERROR = 66
 ZYPPER_IS_LOCKED = 7
 ZYPPER_UNKNOWN_ERROR = 1
+
+
+class Defaults:
+    @staticmethod
+    def get_managed_files(directory):
+        result = []
+        managed = {
+            '/etc': [
+                '/etc/zypp',
+                '/etc/pki/trust/anchors',
+                SUMA_REGISTRY_CONF_PATH,
+                DOCKER_CONFIG_PATH,
+                REGISTRIES_CONF_PATH,
+                PROFILE_LOCAL_PATH,
+                REGISTRY_CREDENTIALS_PATH,
+                HOSTSFILE_PATH,
+            ]
+        }
+        for data in managed.get(directory) or []:
+            if os.path.exists(data):
+                result.append(data)
+        return result

--- a/cloudregister/exceptions.py
+++ b/cloudregister/exceptions.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2025, SUSE LLC, All rights reserved.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+
+
+class CloudRegisterError(Exception):
+    """
+    Base class for registration exceptions
+    """
+
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return format(self.message)
+
+
+class CloudRegisterPathError(CloudRegisterError):
+    """
+    Exception raised if a Path operation e.g mkdir failed
+    """
+
+
+class CloudRegisterScopeError(CloudRegisterError):
+    """
+    Exception raised if a managed file is outside the git scope
+    """
+
+
+class CloudRegisterGitError(CloudRegisterError):
+    """
+    Exception raised if a git operation failed
+    """

--- a/cloudregister/git.py
+++ b/cloudregister/git.py
@@ -1,0 +1,304 @@
+# Copyright (c) 2025, SUSE LLC, All rights reserved.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+import os
+import shutil
+import pathlib
+from collections import namedtuple
+
+from cloudregister.logger import Logger
+from cloudregister.registerutils import (
+    exec_subprocess,
+    get_state_dir,
+    clean_all_standard,
+)
+from cloudregister.defaults import Defaults
+from cloudregister.defaults import REGISTERED_SMT_SERVER_DATA_FILE_NAME
+from cloudregister.exceptions import (
+    CloudRegisterPathError,
+    CloudRegisterScopeError,
+    CloudRegisterGitError,
+)
+
+log = Logger.get_logger()
+
+managed_file_type = namedtuple('managed_file_type', ['new', 'done'])
+
+
+class Git:
+    """
+    Use git for content management of data changed by cloudregister
+    """
+
+    def __init__(self, directory):
+        self.cleanup_called = False
+        self.managed_dir = directory
+        self.managed_dir_git = os.path.normpath(
+            os.sep.join([directory, '.git'])
+        )
+        self.managed_dir_gitignore = os.path.normpath(
+            os.sep.join([directory, '.gitignore'])
+        )
+        self.managed_files = {}
+        registration_smt_cache_file_name = os.path.normpath(
+            os.sep.join([get_state_dir(), REGISTERED_SMT_SERVER_DATA_FILE_NAME])
+        )
+        self.git_cmd = [
+            'git',
+            '--work-tree',
+            self.managed_dir,
+            '--git-dir',
+            self.managed_dir_git,
+        ]
+        if not os.path.isdir(self.managed_dir_git) and os.path.isfile(
+            registration_smt_cache_file_name
+        ):
+            # The system is already registered but is not using the
+            # git content manager. The origin state is therefore
+            # dirty and needs to be cleaned up first with the
+            # standard cleanup code. From there the new git based
+            # content management can be established.
+            clean_all_standard()
+
+        failed = False
+        if not os.path.isdir(self.managed_dir_git):
+            # git cannot manage empty directories
+            # make sure there are none
+            _, error, failed = exec_subprocess(
+                [
+                    'find',
+                    self.managed_dir,
+                    '-type',
+                    'd',
+                    '-empty',
+                    '-exec',
+                    'touch',
+                    '{}/.gitignore',
+                    ';',
+                ]
+            )
+            if not failed:
+                _, error, failed = exec_subprocess(
+                    ['git', 'init', self.managed_dir]
+                )
+            if not failed:
+                _, error, failed = exec_subprocess(
+                    self.git_cmd
+                    + ['config', 'user.email', 'public-cloud-dev@susecloud.net']
+                )
+            if not failed:
+                _, error, failed = exec_subprocess(
+                    self.git_cmd + ['config', 'user.name', 'Public Cloud Team']
+                )
+            if not failed:
+                _, error, failed = exec_subprocess(
+                    self.git_cmd + ['checkout', '-b', 'main']
+                )
+            if not failed:
+                managed_system_files = Defaults.get_managed_files(
+                    self.managed_dir
+                )
+                if managed_system_files:
+                    _, error, failed = exec_subprocess(
+                        self.git_cmd + ['add'] + managed_system_files
+                    )
+            if not failed:
+                _, error, failed = exec_subprocess(
+                    self.git_cmd + ['commit', '--allow-empty', '-m', 'origin']
+                )
+        if not failed:
+            _, error, failed = exec_subprocess(
+                self.git_cmd + ['checkout', 'registercloudguest']
+            )
+            if failed:
+                _, error, failed = exec_subprocess(
+                    self.git_cmd + ['checkout', '-b', 'registercloudguest']
+                )
+        if failed:
+            raise CloudRegisterGitError(
+                'Cannot init git at: {}: {}'.format(self.managed_dir, error)
+            )
+
+    def __enter__(self):
+        return self
+
+    def manage(self, filename):
+        if not self._is_managed(filename):
+            if not os.path.exists(filename):
+                self._manage_new(filename)
+            else:
+                self._manage_existing(filename)
+
+    def done(self, lookup_filename=None):
+        """
+        Mark file as being fully processed, this excludes it from
+        the cleanup phase until explicitly requested via cleanup().
+        If no lookup_filename is given, all files known to the
+        instance will be marked as done
+        """
+        for filename, managed in self.managed_files.items():
+            if filename and lookup_filename != filename:
+                next
+            self.managed_files[filename] = managed_file_type(
+                new=managed.new, done=True
+            )
+
+    def cleanup(self, with_patch=True):
+        """
+        Track modifications not done by us in a patch file.
+        Next go back to the main origin and delete the branch,
+        followed by the deletion of the git itself.
+        """
+        try:
+            self.cleanup_called = True
+            _, error, failed = exec_subprocess(
+                self.git_cmd + ['checkout', 'main']
+            )
+            if failed:
+                if with_patch:
+                    # There are local modifications not done by us
+                    # We preserve them as a patch file
+                    patch_file = '/var/tmp/cloudregister.patch'
+                    log.warning(
+                        'Changes detected in cloudregister managed files'
+                    )
+                    log.warning(
+                        'Please apply {} to not loose them'.format(patch_file)
+                    )
+                    exec_subprocess(
+                        self.git_cmd
+                        + [
+                            'diff',
+                            '--diff-filter=M',
+                            '--output={}'.format(patch_file),
+                        ]
+                    )
+                exec_subprocess(self.git_cmd + ['checkout', '.'])
+                exec_subprocess(self.git_cmd + ['checkout', 'main'])
+            exec_subprocess(
+                self.git_cmd + ['branch', '-D', 'registercloudguest']
+            )
+        finally:
+            shutil.rmtree(self.managed_dir_git)
+            pathlib.Path(self.managed_dir_gitignore).unlink(missing_ok=True)
+
+    def reset(self):
+        """
+        Reset all local modifications and go back to the main
+        origin. Recreate the work branch registercloudguest
+        and switch to it
+        """
+        exec_subprocess(self.git_cmd + ['checkout', '.'])
+        exec_subprocess(self.git_cmd + ['checkout', 'main'])
+        exec_subprocess(self.git_cmd + ['branch', '-D', 'registercloudguest'])
+        exec_subprocess(self.git_cmd + ['checkout', '-b', 'registercloudguest'])
+        self.managed_files = {}
+
+    @staticmethod
+    def git_managed(directory):
+        return os.path.isdir('{}/.git'.format(directory))
+
+    def _is_managed(self, filename):
+        if not filename.startswith(self.managed_dir):
+            raise CloudRegisterScopeError(
+                'Given filename {} is outside git scope dir: {}'.format(
+                    filename, self.managed_dir
+                )
+            )
+        if self.managed_files.get(filename):
+            return True
+        return False
+
+    def _manage_new(self, filename):
+        """
+        Commit a net new file to the git
+        """
+        failed = False
+        log.info('Manage new file: {}'.format(filename))
+        self.managed_files[filename] = managed_file_type(new=True, done=False)
+        try:
+            with open(filename, 'w'):
+                pass
+        except Exception as issue:
+            raise CloudRegisterPathError(
+                'Failed to create new file: {}'.format(issue)
+            )
+        if not failed:
+            stdout, stderr, failed = exec_subprocess(
+                self.git_cmd + ['add', filename]
+            )
+        if not failed:
+            stdout, stderr, failed = exec_subprocess(
+                self.git_cmd
+                + [
+                    'commit',
+                    '--allow-empty',
+                    '-m',
+                    'origin:{}'.format(filename),
+                ]
+            )
+        if failed:
+            raise CloudRegisterGitError(
+                'Failed to add managed file to git: {}:{}'.format(
+                    stdout, stderr
+                )
+            )
+
+    def _manage_existing(self, filename):
+        """
+        Commit an existing file as origin version to the git once
+        such that it can be restored
+        """
+        log.info('Manage existing file: {}'.format(filename))
+        self.managed_files[filename] = managed_file_type(new=False, done=False)
+        if self._known_to_git(filename):
+            log.info('File {} already managed'.format(filename))
+            return
+        stdout, stderr, failed = exec_subprocess(
+            self.git_cmd + ['add', filename]
+        )
+        if not failed:
+            stdout, stderr, failed = exec_subprocess(
+                self.git_cmd + ['commit', '-m', 'origin:{}'.format(filename)]
+            )
+        if failed:
+            raise CloudRegisterGitError(
+                'Failed to add managed file to git: {}:{}'.format(
+                    stdout, stderr
+                )
+            )
+
+    def _known_to_git(self, filename):
+        _, _, failed = exec_subprocess(
+            self.git_cmd + ['ls-files', '--error-unmatch', filename]
+        )
+        if not failed:
+            return True
+        return False
+
+    def _finalize(self):
+        """
+        Cleanup context manager
+        """
+        registration_success = True
+        for filename, managed in self.managed_files.items():
+            if not managed.done:
+                registration_success = False
+        if not registration_success:
+            self.cleanup(with_patch=False)
+        elif registration_success and self.managed_files:
+            exec_subprocess(self.git_cmd + ['commit', '-a', '-m', 'registered'])
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not self.cleanup_called:
+            self._finalize()

--- a/cloudregister/git.py
+++ b/cloudregister/git.py
@@ -1,0 +1,308 @@
+# Copyright (c) 2025, SUSE LLC, All rights reserved.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3.0 of the License, or (at your option) any later version.
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.
+#
+import os
+import shutil
+import pathlib
+from collections import namedtuple
+
+from cloudregister.logger import Logger
+from cloudregister.registerutils import (
+    exec_subprocess,
+    clean_all_standard,
+)
+from cloudregister.defaults import Defaults
+from cloudregister.defaults import (
+    REGISTERED_SMT_SERVER_DATA_FILE_NAME,
+    REGISTRATION_DATA_DIR,
+)
+from cloudregister.exceptions import (
+    CloudRegisterPathError,
+    CloudRegisterScopeError,
+    CloudRegisterGitError,
+)
+
+log = Logger.get_logger()
+
+managed_file_type = namedtuple('managed_file_type', ['new', 'done'])
+
+
+class Git:
+    """
+    Use git for content management of data changed by cloudregister
+    """
+
+    def __init__(self, directory):
+        self.cleanup_called = False
+        self.managed_dir = directory
+        self.managed_dir_git = os.path.normpath(
+            os.sep.join([directory, '.git'])
+        )
+        self.managed_dir_gitignore = os.path.normpath(
+            os.sep.join([directory, '.gitignore'])
+        )
+        self.managed_files = {}
+        registration_smt_cache_file_name = os.path.normpath(
+            os.sep.join(
+                [REGISTRATION_DATA_DIR, REGISTERED_SMT_SERVER_DATA_FILE_NAME]
+            )
+        )
+        self.git_cmd = [
+            'git',
+            '--work-tree',
+            self.managed_dir,
+            '--git-dir',
+            self.managed_dir_git,
+        ]
+        if not os.path.isdir(self.managed_dir_git) and os.path.isfile(
+            registration_smt_cache_file_name
+        ):
+            # The system is already registered but is not using the
+            # git content manager. The origin state is therefore
+            # dirty and needs to be cleaned up first with the
+            # standard cleanup code. From there the new git based
+            # content management can be established.
+            clean_all_standard()
+
+        failed = False
+        if not os.path.isdir(self.managed_dir_git):
+            # git cannot manage empty directories
+            # make sure there are none
+            _, error, failed = exec_subprocess(
+                [
+                    'find',
+                    self.managed_dir,
+                    '-type',
+                    'd',
+                    '-empty',
+                    '-exec',
+                    'touch',
+                    '{}/.gitignore',
+                    ';',
+                ]
+            )
+            if not failed:
+                _, error, failed = exec_subprocess(
+                    ['git', 'init', self.managed_dir]
+                )
+            if not failed:
+                _, error, failed = exec_subprocess(
+                    self.git_cmd
+                    + ['config', 'user.email', 'public-cloud-dev@susecloud.net']
+                )
+            if not failed:
+                _, error, failed = exec_subprocess(
+                    self.git_cmd + ['config', 'user.name', 'Public Cloud Team']
+                )
+            if not failed:
+                _, error, failed = exec_subprocess(
+                    self.git_cmd + ['checkout', '-b', 'main']
+                )
+            if not failed:
+                managed_system_files = Defaults.get_managed_files(
+                    self.managed_dir
+                )
+                if managed_system_files:
+                    _, error, failed = exec_subprocess(
+                        self.git_cmd + ['add'] + managed_system_files
+                    )
+            if not failed:
+                _, error, failed = exec_subprocess(
+                    self.git_cmd + ['commit', '--allow-empty', '-m', 'origin']
+                )
+        if not failed:
+            _, error, failed = exec_subprocess(
+                self.git_cmd + ['checkout', 'registercloudguest']
+            )
+            if failed:
+                _, error, failed = exec_subprocess(
+                    self.git_cmd + ['checkout', '-b', 'registercloudguest']
+                )
+        if failed:
+            raise CloudRegisterGitError(
+                'Cannot init git at: {}: {}'.format(self.managed_dir, error)
+            )
+
+    def __enter__(self):
+        return self
+
+    def manage(self, filename):
+        if not self._is_managed(filename):
+            if not os.path.exists(filename):
+                self._manage_new(filename)
+            else:
+                self._manage_existing(filename)
+
+    def done(self, lookup_filename=None):
+        """
+        Mark file as being fully processed, this excludes it from
+        the cleanup phase until explicitly requested via cleanup().
+        If no lookup_filename is given, all files known to the
+        instance will be marked as done
+        """
+        for filename, managed in self.managed_files.items():
+            if filename and lookup_filename != filename:
+                next
+            self.managed_files[filename] = managed_file_type(
+                new=managed.new, done=True
+            )
+
+    def cleanup(self, with_patch=True):
+        """
+        Track modifications not done by us in a patch file.
+        Next go back to the main origin and delete the branch,
+        followed by the deletion of the git itself.
+        """
+        try:
+            self.cleanup_called = True
+            _, error, failed = exec_subprocess(
+                self.git_cmd + ['checkout', 'main']
+            )
+            if failed:
+                if with_patch:
+                    # There are local modifications not done by us
+                    # We preserve them as a patch file
+                    patch_file = '/var/tmp/cloudregister.patch'
+                    log.warning(
+                        'Changes detected in cloudregister managed files'
+                    )
+                    log.warning(
+                        'Please apply {} to not loose them'.format(patch_file)
+                    )
+                    exec_subprocess(
+                        self.git_cmd
+                        + [
+                            'diff',
+                            '--diff-filter=M',
+                            '--output={}'.format(patch_file),
+                        ]
+                    )
+                exec_subprocess(self.git_cmd + ['checkout', '.'])
+                exec_subprocess(self.git_cmd + ['checkout', 'main'])
+            exec_subprocess(
+                self.git_cmd + ['branch', '-D', 'registercloudguest']
+            )
+        finally:
+            shutil.rmtree(self.managed_dir_git)
+            pathlib.Path(self.managed_dir_gitignore).unlink(missing_ok=True)
+
+    def reset(self):
+        """
+        Reset all local modifications and go back to the main
+        origin. Recreate the work branch registercloudguest
+        and switch to it
+        """
+        exec_subprocess(self.git_cmd + ['checkout', '.'])
+        exec_subprocess(self.git_cmd + ['checkout', 'main'])
+        exec_subprocess(self.git_cmd + ['branch', '-D', 'registercloudguest'])
+        exec_subprocess(self.git_cmd + ['checkout', '-b', 'registercloudguest'])
+        self.managed_files = {}
+
+    @staticmethod
+    def git_managed(directory):
+        return os.path.isdir('{}/.git'.format(directory))
+
+    def _is_managed(self, filename):
+        if not filename.startswith(self.managed_dir):
+            raise CloudRegisterScopeError(
+                'Given filename {} is outside git scope dir: {}'.format(
+                    filename, self.managed_dir
+                )
+            )
+        if self.managed_files.get(filename):
+            return True
+        return False
+
+    def _manage_new(self, filename):
+        """
+        Commit a net new file to the git
+        """
+        failed = False
+        log.info('Manage new file: {}'.format(filename))
+        self.managed_files[filename] = managed_file_type(new=True, done=False)
+        try:
+            with open(filename, 'w'):
+                pass
+        except Exception as issue:
+            raise CloudRegisterPathError(
+                'Failed to create new file: {}'.format(issue)
+            )
+        if not failed:
+            stdout, stderr, failed = exec_subprocess(
+                self.git_cmd + ['add', filename]
+            )
+        if not failed:
+            stdout, stderr, failed = exec_subprocess(
+                self.git_cmd
+                + [
+                    'commit',
+                    '--allow-empty',
+                    '-m',
+                    'origin:{}'.format(filename),
+                ]
+            )
+        if failed:
+            raise CloudRegisterGitError(
+                'Failed to add managed file to git: {}:{}'.format(
+                    stdout, stderr
+                )
+            )
+
+    def _manage_existing(self, filename):
+        """
+        Commit an existing file as origin version to the git once
+        such that it can be restored
+        """
+        log.info('Manage existing file: {}'.format(filename))
+        self.managed_files[filename] = managed_file_type(new=False, done=False)
+        if self._known_to_git(filename):
+            log.info('File {} already managed'.format(filename))
+            return
+        stdout, stderr, failed = exec_subprocess(
+            self.git_cmd + ['add', filename]
+        )
+        if not failed:
+            stdout, stderr, failed = exec_subprocess(
+                self.git_cmd + ['commit', '-m', 'origin:{}'.format(filename)]
+            )
+        if failed:
+            raise CloudRegisterGitError(
+                'Failed to add managed file to git: {}:{}'.format(
+                    stdout, stderr
+                )
+            )
+
+    def _known_to_git(self, filename):
+        _, _, failed = exec_subprocess(
+            self.git_cmd + ['ls-files', '--error-unmatch', filename]
+        )
+        if not failed:
+            return True
+        return False
+
+    def _finalize(self):
+        """
+        Cleanup context manager
+        """
+        registration_success = True
+        for filename, managed in self.managed_files.items():
+            if not managed.done:
+                registration_success = False
+        if not registration_success:
+            self.cleanup(with_patch=False)
+        elif registration_success and self.managed_files:
+            exec_subprocess(self.git_cmd + ['commit', '-a', '-m', 'registered'])
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not self.cleanup_called:
+            self._finalize()

--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -27,6 +27,7 @@ Logic:
 2.) Check if already registered
 3.) Register"""
 
+from contextlib import ExitStack
 import argparse
 import ipaddress
 import os
@@ -37,6 +38,7 @@ import urllib.parse
 import uuid
 
 from cloudregister.lock import Lock
+from cloudregister.git import Git
 from cloudregister.logger import Logger
 from cloudregister.defaults import (
     AVAILABLE_SMT_SERVER_DATA_FILE_NAME,
@@ -166,13 +168,47 @@ def register_modules(
 
 
 # ----------------------------------------------------------------------------
-def cleanup():
+def cleanup(etc_content=None, var_cache_cloudregister_content=None):
     """
     Cleanup registration data. This covers sending
     delete requests to the API servers as well as deletion of
-    cache and etc files.
+    cache and etc files. With content providers the cleanup
+    of files will be handled through git.
     """
-    utils.clean_all_standard()
+    if etc_content or var_cache_cloudregister_content:
+        if etc_content:
+            utils.deregister_non_free_extensions()
+            utils.deregister_from_update_infrastructure()
+            utils.deregister_from_SCC()
+            etc_content.done()
+            etc_content.cleanup()
+        if var_cache_cloudregister_content:
+            var_cache_cloudregister_content.done()
+            var_cache_cloudregister_content.cleanup()
+    else:
+        utils.clean_all_standard()
+
+
+# ----------------------------------------------------------------------------
+def reset(etc_content=None, var_cache_cloudregister_content=None):
+    """
+    Reset local modifications, keep the git
+    """
+    if etc_content:
+        etc_content.reset()
+    if var_cache_cloudregister_content:
+        var_cache_cloudregister_content.reset()
+
+
+# ----------------------------------------------------------------------------
+def done(etc_content=None, var_cache_cloudregister_content=None):
+    """
+    With content providers mark them done
+    """
+    if etc_content:
+        etc_content.done()
+    if var_cache_cloudregister_content:
+        var_cache_cloudregister_content.done()
 
 
 # ----------------------------------------------------------------------------
@@ -563,7 +599,9 @@ def get_update_servers(region_smt_data, cfg):
 
 # ----------------------------------------------------------------------------
 argparse = argparse.ArgumentParser(description='Register on-demand instance')
-argparse.add_argument(
+gitgroup = argparse.add_mutually_exclusive_group()
+forcegroup = argparse.add_mutually_exclusive_group()
+forcegroup.add_argument(
     '--clean',
     action='store_true',
     dest='clean_up',
@@ -576,6 +614,13 @@ argparse.add_argument(
     default=False,
     dest='debug',
     help='Increase verbosity of logfile information',
+)
+gitgroup.add_argument(
+    '--git',
+    action='store_true',
+    default=False,
+    dest='git',
+    help='Use git for content management of registration data',
 )
 argparse.add_argument(
     '-d',
@@ -593,7 +638,7 @@ argparse.add_argument(
     dest='config_file',
     help='Path to config file, default: /etc/regionserverclnt.cfg',
 )
-argparse.add_argument(
+forcegroup.add_argument(
     '--force-new',
     action='store_true',
     dest='force_new_registration',
@@ -612,11 +657,11 @@ argparse.add_argument('--smt-ip', dest='user_smt_ip', help=help_msg)
 help_msg = 'Email address for product registration'
 argparse.add_argument('-e', '--email', dest='email', help=help_msg)
 help_msg = 'The registration code'
-argparse.add_argument('-r', '--regcode', dest='reg_code', help=help_msg)
+gitgroup.add_argument('-r', '--regcode', dest='reg_code', help=help_msg)
 argparse.add_argument('-v', '--version', action='version', version=__version__)
 
 
-def main(args):
+def main(args, etc_content=None, var_cache_cloudregister_content=None):
     log.debug('registercloudguest {}'.format(__version__))
     global registration_returncode  # noqa: F824
     # Create our cache dir, we can nolonger handle this in the package.
@@ -647,12 +692,7 @@ def main(args):
             log.error(error_message)
             sys.exit(1)
 
-    if args.clean_up and args.force_new_registration:
-        msg = '--clean and --force-new are incompatible, use one or the other'
-        log.error(msg)
-        sys.exit(1)
-
-    # Specifying reg code only works, but an e-mail requires a reg code
+    # Using an e-mail requires a reg code
     if args.email and not args.reg_code:
         msg = '--email and --regcode must be used together'
         log.error(msg)
@@ -669,7 +709,7 @@ def main(args):
 
     if args.clean_up:
         log.debug('Registration clean up initiated by user')
-        cleanup()
+        cleanup(etc_content, var_cache_cloudregister_content)
         sys.exit(0)
 
     if not os.path.isdir(utils.get_state_dir()):
@@ -705,7 +745,7 @@ def main(args):
             msg += 'has completed'
             log.warning(msg)
             sys.exit(1)
-        cleanup()
+        reset(etc_content, var_cache_cloudregister_content)
         utils.set_new_registration_flag()
         utils.write_framework_identifier(cfg)
         cached_smt_servers = []
@@ -735,7 +775,7 @@ def main(args):
         )
     elif region_change:
         log.debug('Region change detected, registering to new servers')
-        cleanup()
+        reset(etc_content, var_cache_cloudregister_content)
         region_smt_servers = cached_smt_servers = []
         registration_smt = None
         utils.set_new_registration_flag()
@@ -762,9 +802,15 @@ def main(args):
         inst_data_out.close()
 
     if registration_target_found:
+        # The system is properly registered, run through the checklist now:
+        # Mark all created/modified files from the content manager as
+        # done so far
+        done(etc_content, var_cache_cloudregister_content)
+
         # 1. check/setup the container registry for this target
         if not setup_registry(registration_smt):
-            utils.clean_registry_setup()
+            if not etc_content:
+                utils.clean_registry_setup()
             sys.exit(1)
 
         # 2. check/setup if we got a regcode which is handled as LTSS
@@ -772,6 +818,9 @@ def main(args):
             setup_ltss_registration(
                 registration_smt, args.reg_code, instance_data_filepath
             )
+
+        # Mark all created/modified files from the content manager as done
+        done(etc_content, var_cache_cloudregister_content)
 
         # All done, time to leave...
         sys.exit(0)
@@ -783,6 +832,8 @@ def main(args):
             'System already uses the update infrastructure with a '
             'registration code, nothing to do'
         )
+        # Mark all created/modified files from the content manager as done
+        done(etc_content, var_cache_cloudregister_content)
         sys.exit(0)
 
     # The system is not yet registered, Figure out which server
@@ -844,12 +895,19 @@ def main(args):
         )
         sys.exit(registration_returncode)
 
+    # Mark all created/modified files from the content manager for
+    # the plain registration as done.
+    done(etc_content, var_cache_cloudregister_content)
+
     # Setup container registry
     if not setup_registry(registration_target):
-        cleanup()
+        cleanup(etc_content, var_cache_cloudregister_content)
         sys.exit(1)
 
     utils.set_registration_completed_flag()
+
+    # Mark all created/modified files from the content manager as done
+    done(etc_content, var_cache_cloudregister_content)
 
     log.info('Registration succeeded')
 
@@ -890,6 +948,20 @@ def app():  # pragma: no cover
     try:
         fd = lock.acquire()
         if not fd == Lock.sameProcess():
-            main(args)
+            if args.git or Git.git_managed('/etc'):
+                with ExitStack() as stack:
+                    utils.etc_content = Git('/etc')
+                    stack.push(utils.etc_content)
+                    utils.var_cache_cloudregister_content = Git(
+                        '/var/cache/cloudregister'
+                    )
+                    stack.push(utils.var_cache_cloudregister_content)
+                    main(
+                        args,
+                        utils.etc_content,
+                        utils.var_cache_cloudregister_content,
+                    )
+            else:
+                main(args)
     finally:
         lock.release(fd)

--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -27,6 +27,7 @@ Logic:
 2.) Check if already registered
 3.) Register"""
 
+from contextlib import ExitStack
 import argparse
 import ipaddress
 import os
@@ -37,6 +38,7 @@ import urllib.parse
 
 
 from cloudregister.lock import Lock
+from cloudregister.git import Git
 from cloudregister.logger import Logger
 from cloudregister.defaults import (
     AVAILABLE_SMT_SERVER_DATA_FILE_NAME,
@@ -166,13 +168,47 @@ def register_modules(
 
 
 # ----------------------------------------------------------------------------
-def cleanup():
+def cleanup(etc_content=None, var_cache_cloudregister_content=None):
     """
     Cleanup registration data. This covers sending
     delete requests to the API servers as well as deletion of
-    cache and etc files.
+    cache and etc files. With content providers the cleanup
+    of files will be handled through git.
     """
-    utils.clean_all_standard()
+    if etc_content or var_cache_cloudregister_content:
+        if etc_content:
+            utils.deregister_non_free_extensions()
+            utils.deregister_from_update_infrastructure()
+            utils.deregister_from_SCC()
+            etc_content.done()
+            etc_content.cleanup()
+        if var_cache_cloudregister_content:
+            var_cache_cloudregister_content.done()
+            var_cache_cloudregister_content.cleanup()
+    else:
+        utils.clean_all_standard()
+
+
+# ----------------------------------------------------------------------------
+def reset(etc_content=None, var_cache_cloudregister_content=None):
+    """
+    Reset local modifications, keep the git
+    """
+    if etc_content:
+        etc_content.reset()
+    if var_cache_cloudregister_content:
+        var_cache_cloudregister_content.reset()
+
+
+# ----------------------------------------------------------------------------
+def done(etc_content=None, var_cache_cloudregister_content=None):
+    """
+    With content providers mark them done
+    """
+    if etc_content:
+        etc_content.done()
+    if var_cache_cloudregister_content:
+        var_cache_cloudregister_content.done()
 
 
 # ----------------------------------------------------------------------------
@@ -566,7 +602,9 @@ def get_update_servers(region_smt_data, cfg):
 
 # ----------------------------------------------------------------------------
 argparse = argparse.ArgumentParser(description='Register on-demand instance')
-argparse.add_argument(
+gitgroup = argparse.add_mutually_exclusive_group()
+forcegroup = argparse.add_mutually_exclusive_group()
+forcegroup.add_argument(
     '--clean',
     action='store_true',
     dest='clean_up',
@@ -579,6 +617,13 @@ argparse.add_argument(
     default=False,
     dest='debug',
     help='Increase verbosity of logfile information',
+)
+gitgroup.add_argument(
+    '--git',
+    action='store_true',
+    default=False,
+    dest='git',
+    help='Use git for content management of registration data',
 )
 argparse.add_argument(
     '-d',
@@ -596,7 +641,7 @@ argparse.add_argument(
     dest='config_file',
     help='Path to config file, default: /etc/regionserverclnt.cfg',
 )
-argparse.add_argument(
+forcegroup.add_argument(
     '--force-new',
     action='store_true',
     dest='force_new_registration',
@@ -615,11 +660,11 @@ argparse.add_argument('--smt-ip', dest='user_smt_ip', help=help_msg)
 help_msg = 'Email address for product registration'
 argparse.add_argument('-e', '--email', dest='email', help=help_msg)
 help_msg = 'The registration code'
-argparse.add_argument('-r', '--regcode', dest='reg_code', help=help_msg)
+gitgroup.add_argument('-r', '--regcode', dest='reg_code', help=help_msg)
 argparse.add_argument('-v', '--version', action='version', version=__version__)
 
 
-def main(args):
+def main(args, etc_content=None, var_cache_cloudregister_content=None):
     log.debug('registercloudguest {}'.format(__version__))
     global registration_returncode  # noqa: F824
     # Create our cache dir, we can nolonger handle this in the package.
@@ -650,12 +695,7 @@ def main(args):
             log.error(error_message)
             sys.exit(1)
 
-    if args.clean_up and args.force_new_registration:
-        msg = '--clean and --force-new are incompatible, use one or the other'
-        log.error(msg)
-        sys.exit(1)
-
-    # Specifying reg code only works, but an e-mail requires a reg code
+    # Using an e-mail requires a reg code
     if args.email and not args.reg_code:
         msg = '--email and --regcode must be used together'
         log.error(msg)
@@ -672,7 +712,7 @@ def main(args):
 
     if args.clean_up:
         log.debug('Registration clean up initiated by user')
-        cleanup()
+        cleanup(etc_content, var_cache_cloudregister_content)
         sys.exit(0)
 
     utils.create_state_dir()
@@ -706,7 +746,7 @@ def main(args):
             msg += 'has completed'
             log.warning(msg)
             sys.exit(1)
-        cleanup()
+        reset(etc_content, var_cache_cloudregister_content)
         utils.set_new_registration_flag()
         utils.write_framework_identifier(cfg)
         cached_smt_servers = []
@@ -736,7 +776,7 @@ def main(args):
         )
     elif region_change:
         log.debug('Region change detected, registering to new servers')
-        cleanup()
+        reset(etc_content, var_cache_cloudregister_content)
         region_smt_servers = cached_smt_servers = []
         registration_smt = None
         utils.set_new_registration_flag()
@@ -753,9 +793,15 @@ def main(args):
 
     instance_data_filepath = utils.write_instance_data(cfg)
     if registration_target_found:
+        # The system is properly registered, run through the checklist now:
+        # Mark all created/modified files from the content manager as
+        # done so far
+        done(etc_content, var_cache_cloudregister_content)
+
         # 1. check/setup the container registry for this target
         if not setup_registry(registration_smt):
-            utils.clean_registry_setup()
+            if not etc_content:
+                utils.clean_registry_setup()
             sys.exit(1)
 
         # 2. check/setup if we got a regcode which is handled as LTSS
@@ -763,6 +809,9 @@ def main(args):
             setup_ltss_registration(
                 registration_smt, args.reg_code, instance_data_filepath
             )
+
+        # Mark all created/modified files from the content manager as done
+        done(etc_content, var_cache_cloudregister_content)
 
         # All done, time to leave...
         sys.exit(0)
@@ -774,6 +823,8 @@ def main(args):
             'System already uses the update infrastructure with a '
             'registration code, nothing to do'
         )
+        # Mark all created/modified files from the content manager as done
+        done(etc_content, var_cache_cloudregister_content)
         sys.exit(0)
 
     # The system is not yet registered, Figure out which server
@@ -833,12 +884,19 @@ def main(args):
         )
         sys.exit(registration_returncode)
 
+    # Mark all created/modified files from the content manager for
+    # the plain registration as done.
+    done(etc_content, var_cache_cloudregister_content)
+
     # Setup container registry
     if not setup_registry(registration_target):
-        cleanup()
+        cleanup(etc_content, var_cache_cloudregister_content)
         sys.exit(1)
 
     utils.set_registration_completed_flag()
+
+    # Mark all created/modified files from the content manager as done
+    done(etc_content, var_cache_cloudregister_content)
 
     log.info('Registration succeeded')
 
@@ -879,6 +937,20 @@ def app():  # pragma: no cover
     try:
         fd = lock.acquire()
         if not fd == Lock.sameProcess():
-            main(args)
+            if args.git or Git.git_managed('/etc'):
+                with ExitStack() as stack:
+                    utils.etc_content = Git('/etc')
+                    stack.push(utils.etc_content)
+                    utils.var_cache_cloudregister_content = Git(
+                        '/var/cache/cloudregister'
+                    )
+                    stack.push(utils.var_cache_cloudregister_content)
+                    main(
+                        args,
+                        utils.etc_content,
+                        utils.var_cache_cloudregister_content,
+                    )
+            else:
+                main(args)
     finally:
         lock.release(fd)

--- a/cloudregister/registerutils.py
+++ b/cloudregister/registerutils.py
@@ -33,6 +33,7 @@ import time
 import toml
 import yaml
 
+from unittest.mock import Mock
 from collections import namedtuple
 from lxml import etree
 from pathlib import Path
@@ -72,6 +73,9 @@ requests.packages.urllib3.disable_warnings(
 
 log = Logger.get_logger()
 
+etc_content = Mock()
+var_cache_cloudregister_content = Mock()
+
 
 # ----------------------------------------------------------------------------
 def add_hosts_entry(smt_server):
@@ -90,6 +94,7 @@ def add_hosts_entry(smt_server):
     if smt_server.get_registry_FQDN():
         entry += '%s\t%s\n' % (smt_ip, smt_server.get_registry_FQDN())
 
+    etc_content.manage('/etc/hosts')
     with open('/etc/hosts', 'a') as hosts_file:
         hosts_file.write(smt_hosts_entry_comment)
         hosts_file.write(entry)
@@ -120,6 +125,7 @@ def clean_all_standard():
     Clean up any registration artifacts
 
     This is the standard method which cleans up registration data
+    without using the git content manager.
     """
     # Clean registrations via API requests
     deregister_non_free_extensions()
@@ -203,6 +209,7 @@ def clean_hosts_file(domain_name=None):
     except IndexError:
         pass
 
+    etc_content.manage(HOSTSFILE_PATH)
     with open(HOSTSFILE_PATH, 'wb') as hosts_file:
         for entry in new_hosts_content:
             hosts_file.write(entry)
@@ -512,6 +519,20 @@ def register_product(
         log_information = log_information.replace(regcode, 'XXXX')
 
     log.debug('Registration: {0}'.format(log_information))
+    etc_content.manage(
+        '{}/{}'.format(ZYPP_CREDENTIALS_PATH, BASE_CREDENTIALS_NAME)
+    )
+
+    # get list of zypp setup files existing prior
+    # registration. Those files will not be taken into account
+    # for the registration client.
+    exclude_zypp_files = []
+    for exclude in (
+        glob.glob('/etc/zypp/repos.d/*.repo'),
+        glob.glob('/etc/zypp/services.d/*.service'),
+        glob.glob('/etc/zypp/credentials.d/*'),
+    ):
+        exclude_zypp_files.append(exclude)  # pragma: no cover
 
     # perform registration
     returncode = ZYPPER_IS_LOCKED
@@ -529,6 +550,24 @@ def register_product(
             time.sleep(wait_time)
             back_off = retry_cnt * 5
             retry_cnt -= 1
+
+    # SUSEConnect created new setup files which it does not delete
+    # on deregistration. Let's add these files to the content manager
+    # such that we can handle them properly during cleanup
+    for repo in glob.glob('/etc/zypp/repos.d/*.repo'):
+        if repo not in exclude_zypp_files:
+            etc_content.manage(repo)
+    for service in glob.glob('/etc/zypp/services.d/*.service'):
+        if service not in exclude_zypp_files:
+            etc_content.manage(service)
+    for credential in glob.glob('/etc/zypp/credentials.d/*'):
+        if (
+            BASE_CREDENTIALS_NAME not in credential
+            and credential not in exclude_zypp_files
+        ):
+            etc_content.manage(credential)
+    for cache_file in glob.glob('{}/*'.format(REGISTRATION_DATA_DIR)):
+        var_cache_cloudregister_content.manage(cache_file)
 
     return suseconnect_type(
         returncode=returncode, output=output.decode(), error=error.decode()
@@ -908,6 +947,7 @@ def get_registry_credentials(set_new):
 # ----------------------------------------------------------------------------
 def write_registry_credentials(content, set_new):
     """Update the registry credentials file with the value of 'content'."""
+    etc_content.manage(REGISTRY_CREDENTIALS_PATH)
     try:
         with open(REGISTRY_CREDENTIALS_PATH, 'w') as cred_json_file:
             json.dump(content, cred_json_file)
@@ -1013,6 +1053,7 @@ def get_registry_conf_file(container_path, container):
 def update_bashrc(content, mode):
     """Update the env vars for the container engines
     with the location of the config file to the bashrc local file."""
+    etc_content.manage(PROFILE_LOCAL_PATH)
     try:
         with open(PROFILE_LOCAL_PATH, mode) as bashrc_file:
             bashrc_file.write(content)
@@ -1296,6 +1337,7 @@ def clean_registries_conf_docker(private_registry_fqdn):
 # ----------------------------------------------------------------------------
 def write_registries_conf(registries_conf, container_path, container_name):
     """Write registries_conf content to container_path."""
+    etc_content.manage(container_path)
     try:
         if container_name == 'podman':
             with open(container_path, 'w') as registries_conf_file:
@@ -2109,7 +2151,9 @@ def is_zypper_running():
 def refresh_zypper_pid_cache():
     """Write the current zypper pid to the cache file"""
     zypper_pid = get_zypper_pid()
-    with open(os.sep.join([get_state_dir(), 'zypper_pid']), 'w') as cache_file:
+    zypper_pid_file = os.sep.join([get_state_dir(), 'zypper_pid'])
+    var_cache_cloudregister_content.manage(zypper_pid_file)
+    with open(zypper_pid_file, 'w') as cache_file:
         cache_file.write(zypper_pid)
 
 
@@ -2273,6 +2317,7 @@ def replace_hosts_entry(current_smt, new_smt):
 # ----------------------------------------------------------------------------
 def store_smt_data(smt_data_file_path, smt):
     """Store the given SMT server information to the given file"""
+    var_cache_cloudregister_content.manage(smt_data_file_path)
     with open(smt_data_file_path, 'wb') as smt_data:
         os.fchmod(smt_data.fileno(), stat.S_IREAD | stat.S_IWRITE)
         p = pickle.Pickler(smt_data)
@@ -2363,7 +2408,9 @@ def write_framework_identifier(cfg):
         if region_hint:
             identifier['region'] = region_hint.split('=')[-1]
 
-    with open(get_framework_identifier_path(), 'w') as framework_file:
+    framework_identifier_file = get_framework_identifier_path()
+    var_cache_cloudregister_content.manage(framework_identifier_file)
+    with open(framework_identifier_file, 'w') as framework_file:
         framework_file.write(json.dumps(identifier))
 
 
@@ -2711,6 +2758,7 @@ def _replace_url_target(config_files, new_smt):
         with open(config_file, 'r') as cfg_file:
             content = cfg_file.read()
         if current_service_server in content:
+            etc_content.manage(config_file)
             with open(config_file, 'w') as new_config:
                 new_config.write(
                     content.replace(current_service_server, new_smt.get_FQDN())
@@ -2868,12 +2916,14 @@ def set_registry_fqdn_suma(private_registry_fqdn):
 # ----------------------------------------------------------------------------
 def _set_state_file(filepath):
     """Create a file with the given path if it does not exist"""
+    var_cache_cloudregister_content.manage(filepath)
     Path(filepath).touch(exist_ok=True)
 
 
 # ----------------------------------------------------------------------------
 def _write_suma_conf(updated_content):
     """Update the SUMA SUMA_REGISTRY_CONF_PATH file with the new content."""
+    etc_content.manage(SUMA_REGISTRY_CONF_PATH)
     try:
         with open(SUMA_REGISTRY_CONF_PATH, 'w') as suma_config:
             yaml.dump(updated_content, suma_config, default_flow_style=False)

--- a/cloudregister/registerutils.py
+++ b/cloudregister/registerutils.py
@@ -34,6 +34,7 @@ import toml
 import yaml
 import uuid
 
+from unittest.mock import Mock
 from collections import namedtuple
 from lxml import etree
 from pathlib import Path
@@ -73,6 +74,9 @@ requests.packages.urllib3.disable_warnings(
 
 log = Logger.get_logger()
 
+etc_content = Mock()
+var_cache_cloudregister_content = Mock()
+
 
 # ----------------------------------------------------------------------------
 def add_hosts_entry(smt_server):
@@ -91,6 +95,7 @@ def add_hosts_entry(smt_server):
     if smt_server.get_registry_FQDN():
         entry += '%s\t%s\n' % (smt_ip, smt_server.get_registry_FQDN())
 
+    etc_content.manage('/etc/hosts')
     with open('/etc/hosts', 'a') as hosts_file:
         hosts_file.write(smt_hosts_entry_comment)
         hosts_file.write(entry)
@@ -121,6 +126,7 @@ def clean_all_standard():
     Clean up any registration artifacts
 
     This is the standard method which cleans up registration data
+    without using the git content manager.
     """
     # Clean registrations via API requests
     deregister_non_free_extensions()
@@ -200,6 +206,7 @@ def clean_hosts_file(domain_name=None):
     except IndexError:
         pass
 
+    etc_content.manage(HOSTSFILE_PATH)
     with open(HOSTSFILE_PATH, 'wb') as hosts_file:
         for entry in new_hosts_content:
             hosts_file.write(entry)
@@ -509,6 +516,20 @@ def register_product(
         log_information = log_information.replace(regcode, 'XXXX')
 
     log.debug('Registration: {0}'.format(log_information))
+    etc_content.manage(
+        '{}/{}'.format(ZYPP_CREDENTIALS_PATH, BASE_CREDENTIALS_NAME)
+    )
+
+    # get list of zypp setup files existing prior
+    # registration. Those files will not be taken into account
+    # for the registration client.
+    exclude_zypp_files = []
+    for exclude in (
+        glob.glob('/etc/zypp/repos.d/*.repo'),
+        glob.glob('/etc/zypp/services.d/*.service'),
+        glob.glob('/etc/zypp/credentials.d/*'),
+    ):
+        exclude_zypp_files.append(exclude)  # pragma: no cover
 
     # perform registration
     returncode = ZYPPER_IS_LOCKED
@@ -526,6 +547,24 @@ def register_product(
             time.sleep(wait_time)
             back_off = retry_cnt * 5
             retry_cnt -= 1
+
+    # SUSEConnect created new setup files which it does not delete
+    # on deregistration. Let's add these files to the content manager
+    # such that we can handle them properly during cleanup
+    for repo in glob.glob('/etc/zypp/repos.d/*.repo'):
+        if repo not in exclude_zypp_files:
+            etc_content.manage(repo)
+    for service in glob.glob('/etc/zypp/services.d/*.service'):
+        if service not in exclude_zypp_files:
+            etc_content.manage(service)
+    for credential in glob.glob('/etc/zypp/credentials.d/*'):
+        if (
+            BASE_CREDENTIALS_NAME not in credential
+            and credential not in exclude_zypp_files
+        ):
+            etc_content.manage(credential)
+    for cache_file in glob.glob('{}/*'.format(REGISTRATION_DATA_DIR)):
+        var_cache_cloudregister_content.manage(cache_file)
 
     return suseconnect_type(
         returncode=returncode, output=output.decode(), error=error.decode()
@@ -906,6 +945,7 @@ def get_registry_credentials(set_new):
 # ----------------------------------------------------------------------------
 def write_registry_credentials(content, set_new):
     """Update the registry credentials file with the value of 'content'."""
+    etc_content.manage(REGISTRY_CREDENTIALS_PATH)
     try:
         with open(REGISTRY_CREDENTIALS_PATH, 'w') as cred_json_file:
             json.dump(content, cred_json_file)
@@ -1011,6 +1051,7 @@ def get_registry_conf_file(container_path, container):
 def update_bashrc(content, mode):
     """Update the env vars for the container engines
     with the location of the config file to the bashrc local file."""
+    etc_content.manage(PROFILE_LOCAL_PATH)
     try:
         with open(PROFILE_LOCAL_PATH, mode) as bashrc_file:
             bashrc_file.write(content)
@@ -1294,6 +1335,7 @@ def clean_registries_conf_docker(private_registry_fqdn):
 # ----------------------------------------------------------------------------
 def write_registries_conf(registries_conf, container_path, container_name):
     """Write registries_conf content to container_path."""
+    etc_content.manage(container_path)
     try:
         if container_name == 'podman':
             with open(container_path, 'w') as registries_conf_file:
@@ -2102,9 +2144,9 @@ def is_zypper_running():
 def refresh_zypper_pid_cache():
     """Write the current zypper pid to the cache file"""
     zypper_pid = get_zypper_pid()
-    with open(
-        os.sep.join([REGISTRATION_DATA_DIR, 'zypper_pid']), 'w'
-    ) as cache_file:
+    zypper_pid_file = os.sep.join([REGISTRATION_DATA_DIR, 'zypper_pid'])
+    var_cache_cloudregister_content.manage(zypper_pid_file)
+    with open(zypper_pid_file, 'w') as cache_file:
         cache_file.write(zypper_pid)
 
 
@@ -2271,6 +2313,7 @@ def replace_hosts_entry(current_smt, new_smt):
 # ----------------------------------------------------------------------------
 def store_smt_data(smt_data_file_path, smt):
     """Store the given SMT server information to the given file"""
+    var_cache_cloudregister_content.manage(smt_data_file_path)
     with open(smt_data_file_path, 'wb') as smt_data:
         os.fchmod(smt_data.fileno(), stat.S_IREAD | stat.S_IWRITE)
         p = pickle.Pickler(smt_data)
@@ -2361,7 +2404,9 @@ def write_framework_identifier(cfg):
         if region_hint:
             identifier['region'] = region_hint.split('=')[-1]
 
-    with open(get_framework_identifier_path(), 'w') as framework_file:
+    framework_identifier_file = get_framework_identifier_path()
+    var_cache_cloudregister_content.manage(framework_identifier_file)
+    with open(framework_identifier_file, 'w') as framework_file:
         framework_file.write(json.dumps(identifier))
 
 
@@ -2721,6 +2766,7 @@ def _replace_url_target(config_files, new_smt):
         with open(config_file, 'r') as cfg_file:
             content = cfg_file.read()
         if current_service_server in content:
+            etc_content.manage(config_file)
             with open(config_file, 'w') as new_config:
                 new_config.write(
                     content.replace(current_service_server, new_smt.get_FQDN())
@@ -2896,12 +2942,14 @@ def write_instance_data(cfg=None):
 # ----------------------------------------------------------------------------
 def _set_state_file(filepath):
     """Create a file with the given path if it does not exist"""
+    var_cache_cloudregister_content.manage(filepath)
     Path(filepath).touch(exist_ok=True)
 
 
 # ----------------------------------------------------------------------------
 def _write_suma_conf(updated_content):
     """Update the SUMA SUMA_REGISTRY_CONF_PATH file with the new content."""
+    etc_content.manage(SUMA_REGISTRY_CONF_PATH)
     try:
         with open(SUMA_REGISTRY_CONF_PATH, 'w') as suma_config:
             yaml.dump(updated_content, suma_config, default_flow_style=False)

--- a/cloudregister/smt.py
+++ b/cloudregister/smt.py
@@ -202,7 +202,7 @@ class SMT:
         self._protocol = protocol
 
     # --------------------------------------------------------------------
-    def write_cert(self, target_dir):
+    def write_cert(self, target_dir, etc_content=None):
         """Write the certificate to the given directory"""
         cert = self.get_cert()
         if not cert:
@@ -227,7 +227,9 @@ class SMT:
         # we write here with the known pattern.
         for cert_name in certs_to_write:
             try:
-                with open(ca_file_path % cert_name, "w") as smt_ca_file:
+                if etc_content:
+                    etc_content.manage(ca_file_path % cert_name)
+                with open(ca_file_path % cert_name, 'w') as smt_ca_file:
                     smt_ca_file.write(cert)
             except IOError:
                 errMsg = "Could not store update server certificate"

--- a/doc/man/man1/registercloudguest.1
+++ b/doc/man/man1/registercloudguest.1
@@ -51,6 +51,18 @@ removed from SCC.
 Delay the process by the given number of seconds.
 .IP "--debug"
 Debug mode, increase verbosity of logfile information.
+.IP "--git"
+Use git for content management. In this mode a git repo is initialized
+for the /etc directory of the system. All files modified and/or produced
+by the registration client will be managed via the git content manager
+and the registration process runs in a context manager to allow for
+seamless cleanup in case of errors. As files are known to git in this
+mode. Also the user initiated cleanup or force registration will make
+use of the content manager to restore data to is original state. As a
+user there is also the opportunity to watch the changes done by the
+registration client via the git utility. As we can't force git to
+become part of the system, this mode is fully optional and requires
+the installation of the git package prior use.
 .IP "-e --email"
 The e-mail address associated with a subscription in SCC. Only use this option
 for BYOS instances and in conjunction with "--regcode" option.

--- a/package/fix-for-sles12-disable-registry.patch
+++ b/package/fix-for-sles12-disable-registry.patch
@@ -1,8 +1,8 @@
 diff --git a/cloudregister/registercloudguest.py b/cloudregister/registercloudguest.py
-index fc16c4e..0df0871 100644
+index 2b377b1..cdbbf61 100644
 --- a/cloudregister/registercloudguest.py
 +++ b/cloudregister/registercloudguest.py
-@@ -154,6 +154,8 @@ def setup_registry(registration_target):
+@@ -164,6 +164,8 @@ def setup_registry(registration_target):
      """
      Run the registration process for the container registry
      """
@@ -12,7 +12,7 @@ index fc16c4e..0df0871 100644
          utils.get_credentials_file(registration_target)
      )
 diff --git a/cloudregister/registerutils.py b/cloudregister/registerutils.py
-index 21e55d0..09c85eb 100644
+index 9b9b0b7..948cbef 100644
 --- a/cloudregister/registerutils.py
 +++ b/cloudregister/registerutils.py
 @@ -29,7 +29,8 @@ import stat
@@ -24,8 +24,8 @@ index 21e55d0..09c85eb 100644
 +# import toml
  import yaml
  
- from collections import namedtuple
-@@ -82,8 +83,9 @@ def add_hosts_entry(smt_server):
+ from unittest.mock import Mock
+@@ -85,8 +86,9 @@ def add_hosts_entry(smt_server):
          smt_server.get_FQDN(),
          smt_server.get_name(),
      )
@@ -35,9 +35,9 @@ index 21e55d0..09c85eb 100644
 +    # if smt_server.get_registry_FQDN():
 +    #     entry += '%s\t%s\n' % (smt_ip, smt_server.get_registry_FQDN())
  
+     etc_content.manage('/etc/hosts')
      with open('/etc/hosts', 'a') as hosts_file:
-         hosts_file.write(smt_hosts_entry_comment)
-@@ -980,6 +982,8 @@ def set_container_engines_env_vars():
+@@ -1016,6 +1018,8 @@ def set_container_engines_env_vars():
  
  # ----------------------------------------------------------------------------
  def get_registry_conf_file(container_path, container):
@@ -46,7 +46,7 @@ index 21e55d0..09c85eb 100644
      registries_conf = {}
      try:
          with open(container_path, 'r') as registries_conf_file:
-@@ -1025,6 +1029,8 @@ def update_bashrc(content, mode):
+@@ -1062,6 +1066,8 @@ def update_bashrc(content, mode):
  # ----------------------------------------------------------------------------
  def clean_registry_setup():
      """Remove the data previously set to make the registry work."""
@@ -55,12 +55,12 @@ index 21e55d0..09c85eb 100644
      smt = get_smt_from_store(_get_registered_smt_file_path())
      private_registry_fqdn = smt.get_registry_FQDN() if smt else ''
      clean_registry_auth(private_registry_fqdn)
-@@ -1294,6 +1300,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
+@@ -1331,6 +1337,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
  # ----------------------------------------------------------------------------
  def write_registries_conf(registries_conf, container_path, container_name):
      """Write registries_conf content to container_path."""
 +    # Disabled on SLE12
 +    # return None
+     etc_content.manage(container_path)
      try:
          if container_name == 'podman':
-             with open(container_path, 'w') as registries_conf_file:

--- a/package/fix-for-sles12-disable-registry.patch
+++ b/package/fix-for-sles12-disable-registry.patch
@@ -1,8 +1,8 @@
 diff --git a/cloudregister/registercloudguest.py b/cloudregister/registercloudguest.py
-index cf7c372..03e2769 100644
+index 072b7d3..72ece89 100644
 --- a/cloudregister/registercloudguest.py
 +++ b/cloudregister/registercloudguest.py
-@@ -180,6 +180,8 @@ def setup_registry(registration_target):
+@@ -216,6 +216,8 @@ def setup_registry(registration_target):
      """
      Run the registration process for the container registry
      """
@@ -12,7 +12,7 @@ index cf7c372..03e2769 100644
          utils.get_credentials_file(registration_target)
      )
 diff --git a/cloudregister/registerutils.py b/cloudregister/registerutils.py
-index 4973b40..5420ef4 100644
+index 315a69a..8e39ce7 100644
 --- a/cloudregister/registerutils.py
 +++ b/cloudregister/registerutils.py
 @@ -30,7 +30,8 @@ import stat
@@ -25,7 +25,7 @@ index 4973b40..5420ef4 100644
  import yaml
  import uuid
  
-@@ -88,8 +89,9 @@ def add_hosts_entry(smt_server):
+@@ -92,8 +93,9 @@ def add_hosts_entry(smt_server):
          smt_server.get_FQDN(),
          smt_server.get_name(),
      )
@@ -35,9 +35,9 @@ index 4973b40..5420ef4 100644
 +    # if smt_server.get_registry_FQDN():
 +    #     entry += '%s\t%s\n' % (smt_ip, smt_server.get_registry_FQDN())
  
+     etc_content.manage('/etc/hosts')
      with open('/etc/hosts', 'a') as hosts_file:
-         hosts_file.write(smt_hosts_entry_comment)
-@@ -983,6 +985,8 @@ def set_container_engines_env_vars():
+@@ -1019,6 +1021,8 @@ def set_container_engines_env_vars():
  
  # ----------------------------------------------------------------------------
  def get_registry_conf_file(container_path, container):
@@ -46,7 +46,7 @@ index 4973b40..5420ef4 100644
      registries_conf = {}
      try:
          with open(container_path, 'r') as registries_conf_file:
-@@ -1028,6 +1032,8 @@ def update_bashrc(content, mode):
+@@ -1065,6 +1069,8 @@ def update_bashrc(content, mode):
  # ----------------------------------------------------------------------------
  def clean_registry_setup():
      """Remove the data previously set to make the registry work."""
@@ -55,12 +55,12 @@ index 4973b40..5420ef4 100644
      smt = get_smt_from_store(_get_registered_smt_file_path())
      private_registry_fqdn = smt.get_registry_FQDN() if smt else ''
      clean_registry_auth(private_registry_fqdn)
-@@ -1297,6 +1303,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
+@@ -1334,6 +1340,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
  # ----------------------------------------------------------------------------
  def write_registries_conf(registries_conf, container_path, container_name):
      """Write registries_conf content to container_path."""
 +    # Disabled on SLE12
 +    # return None
+     etc_content.manage(container_path)
      try:
          if container_name == 'podman':
-             with open(container_path, 'w') as registries_conf_file:

--- a/test/unit/defaults_test.py
+++ b/test/unit/defaults_test.py
@@ -1,0 +1,18 @@
+from unittest.mock import patch
+from cloudregister.defaults import Defaults
+
+
+class TestDefaults:
+    @patch('os.path.exists')
+    def test_get_managed_files(self, mock_os_path_exists):
+        mock_os_path_exists.return_value = True
+        assert Defaults.get_managed_files('/etc') == [
+            '/etc/zypp',
+            '/etc/pki/trust/anchors',
+            '/etc/uyuni/uyuni-tools.yaml',
+            '/etc/docker/daemon.json',
+            '/etc/containers/registries.conf',
+            '/etc/profile.local',
+            '/etc/containers/config.json',
+            '/etc/hosts',
+        ]

--- a/test/unit/exceptions_test.py
+++ b/test/unit/exceptions_test.py
@@ -1,0 +1,8 @@
+from cloudregister.exceptions import CloudRegisterPathError
+
+
+class TestCloudRegister:
+    def test_raise_message_representation(self):
+        exception = CloudRegisterPathError('some_error')
+        message = format(exception)
+        assert message == 'some_error'

--- a/test/unit/git_test.py
+++ b/test/unit/git_test.py
@@ -1,0 +1,476 @@
+from unittest.mock import patch, call
+from pytest import raises, fixture
+from cloudregister.logger import Logger
+from cloudregister.git import Git, managed_file_type
+from cloudregister.exceptions import (
+    CloudRegisterGitError,
+    CloudRegisterScopeError,
+    CloudRegisterPathError,
+)
+
+log_instance = Logger()
+log = Logger.get_logger()
+
+
+class TestGit:
+    @fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
+    @patch('os.path.isdir')
+    @patch('os.path.isfile')
+    @patch('cloudregister.git.exec_subprocess')
+    @patch('cloudregister.git.clean_all_standard')
+    @patch.object(Git, 'cleanup')
+    @patch('cloudregister.git.Defaults')
+    def setup(
+        self,
+        mock_Defaults,
+        mock_cleanup,
+        mock_clean_all_standard,
+        mock_exec_subprocess,
+        mock_os_path_isfile,
+        mock_os_path_isdir,
+    ):
+        mock_Defaults.get_managed_files.return_value = ['some']
+
+        # test init with new registercloudguest branch
+        mock_exec_subprocess.return_value = (b'stdout', b'stderr', 1)
+        mock_os_path_isfile.return_value = False
+        mock_os_path_isdir.return_value = True
+        with raises(CloudRegisterGitError):
+            self.git = Git('/some')
+        assert mock_exec_subprocess.call_args_list == [
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'checkout',
+                    'registercloudguest',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'checkout',
+                    '-b',
+                    'registercloudguest',
+                ]
+            ),
+        ]
+
+        # test init with existing registercloudguest branch
+        mock_exec_subprocess.reset_mock()
+        mock_exec_subprocess.return_value = (b'stdout', b'stderr', 0)
+        mock_os_path_isfile.return_value = True
+        mock_os_path_isdir.return_value = False
+        self.git = Git('/some')
+        mock_clean_all_standard.assert_called_once_with()
+        assert mock_exec_subprocess.call_args_list == [
+            call(
+                [
+                    'find',
+                    '/some',
+                    '-type',
+                    'd',
+                    '-empty',
+                    '-exec',
+                    'touch',
+                    '{}/.gitignore',
+                    ';',
+                ]
+            ),
+            call(['git', 'init', '/some']),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'config',
+                    'user.email',
+                    'public-cloud-dev@susecloud.net',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'config',
+                    'user.name',
+                    'Public Cloud Team',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'checkout',
+                    '-b',
+                    'main',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'add',
+                    'some',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'commit',
+                    '--allow-empty',
+                    '-m',
+                    'origin',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'checkout',
+                    'registercloudguest',
+                ]
+            ),
+        ]
+
+        # test context manager cleanup
+        mock_exec_subprocess.reset_mock()
+        mock_exec_subprocess.return_value = (b'', b'', 0)
+        with Git('/some') as some_manage:
+            some_manage.managed_files['some'] = managed_file_type(
+                new=True, done=False
+            )
+        mock_cleanup.assert_called_once_with(with_patch=False)
+
+        # test init exception
+        mock_exec_subprocess.return_value = (b'', b'', 1)
+        with raises(CloudRegisterGitError):
+            self.git = Git('/some')
+
+    @patch('os.path.isdir')
+    @patch('os.path.isfile')
+    @patch('cloudregister.git.exec_subprocess')
+    @patch('cloudregister.git.clean_all_standard')
+    def setup_method(
+        self,
+        cls,
+        mock_clean_all_standard,
+        mock_exec_subprocess,
+        mock_os_path_isfile,
+        mock_os_path_isdir,
+    ):
+        self.setup()
+
+    @patch('cloudregister.git.exec_subprocess')
+    def test_context_manager_commit_registered(self, mock_exec_subprocess):
+        self.git.managed_files['some'] = managed_file_type(new=True, done=True)
+        self.git._finalize()
+        mock_exec_subprocess.assert_called_once_with(
+            [
+                'git',
+                '--work-tree',
+                '/some',
+                '--git-dir',
+                '/some/.git',
+                'commit',
+                '-a',
+                '-m',
+                'registered',
+            ]
+        )
+
+    @patch('cloudregister.git.exec_subprocess')
+    def test_known_to_git(self, mock_exec_subprocess):
+        mock_exec_subprocess.return_value = (b'', b'', 0)
+        assert self.git._known_to_git('some') is True
+        mock_exec_subprocess.assert_called_once_with(
+            [
+                'git',
+                '--work-tree',
+                '/some',
+                '--git-dir',
+                '/some/.git',
+                'ls-files',
+                '--error-unmatch',
+                'some',
+            ]
+        )
+        mock_exec_subprocess.return_value = (b'', b'', 1)
+        assert self.git._known_to_git('some') is False
+
+    @patch('os.path.exists')
+    @patch.object(Git, '_is_managed')
+    @patch.object(Git, '_manage_new')
+    @patch.object(Git, '_manage_existing')
+    def test_manage(
+        self,
+        mock_manage_existing,
+        mock_manage_new,
+        mock_is_managed,
+        mock_os_path_exists,
+    ):
+        mock_is_managed.return_value = False
+        mock_os_path_exists.return_value = False
+        self.git.manage('some')
+        mock_manage_new.assert_called_once_with('some')
+        mock_os_path_exists.return_value = True
+        self.git.manage('some')
+        mock_manage_existing.assert_called_once_with('some')
+
+    def test_done(self):
+        self.git.managed_files['some'] = managed_file_type(new=True, done=False)
+        self.git.managed_files['other'] = managed_file_type(
+            new=True, done=False
+        )
+        self.git.done()
+        assert self.git.managed_files['some'].done is True
+
+    @patch('cloudregister.git.exec_subprocess')
+    def test_reset(self, mock_exec_subprocess):
+        self.git.reset()
+        assert mock_exec_subprocess.call_args_list == [
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'checkout',
+                    '.',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'checkout',
+                    'main',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'branch',
+                    '-D',
+                    'registercloudguest',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'checkout',
+                    '-b',
+                    'registercloudguest',
+                ]
+            ),
+        ]
+
+    @patch('cloudregister.git.exec_subprocess')
+    @patch('shutil.rmtree')
+    @patch('pathlib.Path')
+    def test_cleanup(
+        self, mock_pathlib_Path, mock_shutil_rmtree, mock_exec_subprocess
+    ):
+        mock_exec_subprocess.return_value = (b'', b'', 1)
+        self.git.cleanup()
+        assert mock_exec_subprocess.call_args_list == [
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'checkout',
+                    'main',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'diff',
+                    '--diff-filter=M',
+                    '--output=/var/tmp/cloudregister.patch',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'checkout',
+                    '.',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'checkout',
+                    'main',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'branch',
+                    '-D',
+                    'registercloudguest',
+                ]
+            ),
+        ]
+        mock_shutil_rmtree.assert_called_once_with('/some/.git')
+        mock_pathlib_Path.assert_called_once_with('/some/.gitignore')
+        mock_pathlib_Path.return_value.unlink.assert_called_once_with(
+            missing_ok=True
+        )
+
+    def test_is_managed(self):
+        assert self.git._is_managed('/some') is False
+        with raises(CloudRegisterScopeError):
+            self.git._is_managed('other')
+        self.git.managed_files['/some'] = managed_file_type(
+            new=True, done=False
+        )
+        assert self.git._is_managed('/some') is True
+
+    @patch('cloudregister.git.exec_subprocess')
+    @patch('os.path.exists')
+    def test_manage_new(self, mock_os_path_exists, mock_exec_subprocess):
+        mock_os_path_exists.return_value = False
+        mock_exec_subprocess.return_value = (b'', b'', 0)
+        with patch('builtins.open', create=True) as mock_open:
+            mock_open.side_effect = Exception
+            with raises(CloudRegisterPathError):
+                self.git._manage_new('some')
+
+        with patch('builtins.open', create=True):
+            self.git._manage_new('some')
+            assert mock_exec_subprocess.call_args_list == [
+                call(
+                    [
+                        'git',
+                        '--work-tree',
+                        '/some',
+                        '--git-dir',
+                        '/some/.git',
+                        'add',
+                        'some',
+                    ]
+                ),
+                call(
+                    [
+                        'git',
+                        '--work-tree',
+                        '/some',
+                        '--git-dir',
+                        '/some/.git',
+                        'commit',
+                        '--allow-empty',
+                        '-m',
+                        'origin:some',
+                    ]
+                ),
+            ]
+
+        mock_exec_subprocess.return_value = (b'', b'', 1)
+        with patch('builtins.open', create=True):
+            with raises(CloudRegisterGitError):
+                self.git._manage_new('some')
+
+    @patch('cloudregister.git.exec_subprocess')
+    @patch.object(Git, '_known_to_git')
+    def test_manage_existing(self, mock_known_to_git, mock_exec_subprocess):
+        mock_known_to_git.return_value = True
+        self.git._manage_existing('some')
+        assert 'already managed' in self._caplog.text
+        mock_known_to_git.return_value = False
+        mock_exec_subprocess.return_value = (b'', b'', 1)
+        with raises(CloudRegisterGitError):
+            self.git._manage_existing('some')
+        mock_exec_subprocess.reset_mock()
+        mock_exec_subprocess.return_value = (b'', b'', 0)
+        self.git._manage_existing('some')
+        assert mock_exec_subprocess.call_args_list == [
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'add',
+                    'some',
+                ]
+            ),
+            call(
+                [
+                    'git',
+                    '--work-tree',
+                    '/some',
+                    '--git-dir',
+                    '/some/.git',
+                    'commit',
+                    '-m',
+                    'origin:some',
+                ]
+            ),
+        ]
+
+    @patch('os.path.isdir')
+    def test_git_managed(self, mock_os_path_isdir):
+        mock_os_path_isdir.return_value = True
+        assert Git.git_managed('some') is True

--- a/test/unit/registercloudguest_test.py
+++ b/test/unit/registercloudguest_test.py
@@ -43,7 +43,7 @@ class TestRegisterCloudGuest:
             user_smt_fp=None,
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     @patch('os.makedirs')
     @patch('cloudregister.registerutils.has_network_access_by_ip_address')
@@ -57,7 +57,7 @@ class TestRegisterCloudGuest:
             user_smt_fp='AA:BB:CC:DD',
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     @patch('os.makedirs')
     def test_register_cloud_guest_non_ip_value(self, mock_makedirs):
@@ -67,20 +67,7 @@ class TestRegisterCloudGuest:
             user_smt_fp='AA:BB:CC',
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
-
-    @patch('os.makedirs')
-    def test_register_cloud_guest_mixed_param(self, mock_makedirs):
-        fake_args = SimpleNamespace(
-            clean_up=True,
-            force_new_registration=True,
-            user_smt_ip=None,
-            user_smt_fqdn=None,
-            user_smt_fp=None,
-            debug=True,
-        )
-        with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     @patch('os.makedirs')
     def test_register_cloud_guest_no_regcode_email(self, mock_makedirs):
@@ -95,7 +82,7 @@ class TestRegisterCloudGuest:
             debug=True,
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     @patch('os.makedirs')
     @patch('cloudregister.registerutils.clean_hosts_file')
@@ -127,7 +114,7 @@ class TestRegisterCloudGuest:
             debug=False,
         )
         with raises(SystemExit):
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
 
     @patch('cloudregister.registerutils.set_registration_completed_flag')
     @patch('cloudregister.registerutils.set_new_registration_flag')
@@ -175,7 +162,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
 
     @patch('cloudregister.registerutils.set_new_registration_flag')
@@ -222,7 +209,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
 
     @patch.object(SMT, 'is_equivalent')
@@ -307,7 +294,7 @@ class TestRegisterCloudGuest:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
             with self._caplog.at_level(logging.DEBUG):
-                register_cloud_guest.main(fake_args)
+                register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
         assert 'Configured update server is unresponsive' in self._caplog.text
 
@@ -405,7 +392,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -506,7 +493,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, None)
             assert sys_exit.value.code == 1
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -604,7 +591,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.replace_hosts_entry')
@@ -710,7 +697,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -807,7 +794,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -911,7 +898,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
             assert 'No registration executable found' in self._caplog.text
             assert sys_exit.value.code == 1
 
@@ -1020,7 +1007,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -1128,7 +1115,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert 'No products installed on system' in self._caplog.text
         assert sys_exit.value.code == 1
 
@@ -1240,7 +1227,7 @@ class TestRegisterCloudGuest:
         with tempfile.TemporaryDirectory(suffix='foo') as tdir:
             mock_get_state_dir.return_value = tdir
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -1278,10 +1265,8 @@ class TestRegisterCloudGuest:
     @patch('cloudregister.registerutils.deregister_from_update_infrastructure')
     @patch('cloudregister.registerutils.deregister_from_SCC')
     @patch('cloudregister.registerutils.clean_cache')
-    @patch('cloudregister.registerutils.clean_all_standard')
     def test_register_cloud_guest_force_baseprod_registration_failed(
         self,
-        mock_clean_all_standard,
         mock_clean_cache,
         mock_deregister_from_SCC,
         mock_deregister_from_update_infrastructure,
@@ -1367,7 +1352,7 @@ class TestRegisterCloudGuest:
             returncode=67, output='registration code', error='stderr'
         )
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert 'Baseproduct registration failed' in self._caplog.text
         assert sys_exit.value.code == 1
 
@@ -1522,7 +1507,7 @@ class TestRegisterCloudGuest:
         )
         mock_set_proxy.return_value = False
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert (
             'Unable to obtain product information from server "1.2.3.5,None"'
             in self._caplog.text
@@ -1572,10 +1557,8 @@ class TestRegisterCloudGuest:
     @patch('cloudregister.registerutils.deregister_from_update_infrastructure')
     @patch('cloudregister.registerutils.deregister_from_SCC')
     @patch('cloudregister.registerutils.clean_cache')
-    @patch('cloudregister.registerutils.clean_all_standard')
     def test_register_cloud_guest_force_baseprod_extensions_raise(
         self,
-        mock_clean_all_standard,
         mock_clean_cache,
         mock_deregister_from_SCC,
         mock_deregister_from_update_infrastructure,
@@ -1725,7 +1708,7 @@ class TestRegisterCloudGuest:
         mock_set_proxy.return_value = False
         mock_get_register_cmd.return_value = '/usr/sbin/SUSEConnect'
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 6
 
     @patch('cloudregister.registerutils.set_registration_completed_flag')
@@ -1943,7 +1926,7 @@ class TestRegisterCloudGuest:
             fragment='url-parsing',
         )
         mock_set_proxy.return_value = False
-        assert register_cloud_guest.main(fake_args) is None
+        assert register_cloud_guest.main(fake_args, Mock()) is None
         assert 'Forced new registration' in self._caplog.text
         assert (
             'Using user specified SMT server:\n\n\t"IP:1.2.3.5"\n\t"'
@@ -2168,7 +2151,7 @@ class TestRegisterCloudGuest:
             fragment='url-parsing',
         )
         mock_set_proxy.return_value = False
-        assert register_cloud_guest.main(fake_args) is None
+        assert register_cloud_guest.main(fake_args, Mock()) is None
         assert 'Forced new registration' in self._caplog.text
         assert (
             'Using user specified SMT server:\n\n\t"IP:fc00::1"\n\t"'
@@ -2409,7 +2392,7 @@ class TestRegisterCloudGuest:
         )
         mock_set_proxy.return_value = False
 
-        assert register_cloud_guest.main(fake_args) is None
+        assert register_cloud_guest.main(fake_args, Mock()) is None
 
         assert 'Registration succeeded' in self._caplog.text
         assert (
@@ -2641,7 +2624,7 @@ class TestRegisterCloudGuest:
         )
         with raises(SystemExit) as sys_exit:
             with patch('builtins.open', mock_open()):
-                register_cloud_guest.main(fake_args)
+                register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 0
         assert (
             'Region change detected, registering to new servers'
@@ -3114,9 +3097,35 @@ class TestRegisterCloudGuest:
         mock_deregister_from_update_infrastructure,
         mock_deregister_non_free_extensions,
     ):
+        etc_content = Mock()
+        var_cache_cloudregister_content = Mock()
+        # cleanup with content manager(git)...
+        register_cloud_guest.cleanup(
+            etc_content, var_cache_cloudregister_content
+        )
+        mock_deregister_non_free_extensions.assert_called_once_with()
+        mock_deregister_from_update_infrastructure.assert_called_once_with()
+        mock_deregister_from_SCC.assert_called_once_with()
+        etc_content.cleanup.assert_called_once_with()
+        var_cache_cloudregister_content.cleanup.assert_called_once_with()
+
         # cleanup standard style
         register_cloud_guest.cleanup()
         mock_clean_all_standard.assert_called_once_with()
+
+    def test_reset(self):
+        etc_content = Mock()
+        var_cache_cloudregister_content = Mock()
+        register_cloud_guest.reset(etc_content, var_cache_cloudregister_content)
+        etc_content.reset.assert_called_once_with()
+        var_cache_cloudregister_content.reset.assert_called_once_with()
+
+    def test_done(self):
+        etc_content = Mock()
+        var_cache_cloudregister_content = Mock()
+        register_cloud_guest.done(etc_content, var_cache_cloudregister_content)
+        etc_content.done.assert_called_once_with()
+        var_cache_cloudregister_content.done.assert_called_once_with()
 
     @patch('cloudregister.registerutils._remove_state_file')
     @patch('cloudregister.registerutils.set_registration_completed_flag')
@@ -3345,5 +3354,5 @@ class TestRegisterCloudGuest:
         mock_set_proxy.return_value = False
         mock_setup_registry.return_value = False
         with raises(SystemExit) as sys_exit:
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 1

--- a/test/unit/registercloudguest_test.py
+++ b/test/unit/registercloudguest_test.py
@@ -43,7 +43,7 @@ class TestRegisterCloudGuest:
             user_smt_fp=None,
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     @patch('cloudregister.registerutils.create_state_dir')
     @patch('cloudregister.registerutils.has_network_access_by_ip_address')
@@ -57,7 +57,7 @@ class TestRegisterCloudGuest:
             user_smt_fp='AA:BB:CC:DD',
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     @patch('cloudregister.registerutils.create_state_dir')
     def test_register_cloud_guest_non_ip_value(self, mock_create_state_dir):
@@ -67,11 +67,13 @@ class TestRegisterCloudGuest:
             user_smt_fp='AA:BB:CC',
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     @patch('cloudregister.registerutils.create_state_dir')
     def test_register_cloud_guest_mixed_param(self, mock_create_state_dir):
         fake_args = SimpleNamespace(
+            email='foo',
+            reg_code=None,
             clean_up=True,
             force_new_registration=True,
             user_smt_ip=None,
@@ -80,7 +82,7 @@ class TestRegisterCloudGuest:
             debug=True,
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     @patch('cloudregister.registerutils.create_state_dir')
     def test_register_cloud_guest_no_regcode_email(self, mock_create_dir):
@@ -95,7 +97,7 @@ class TestRegisterCloudGuest:
             debug=True,
         )
         with raises(SystemExit):
-            assert register_cloud_guest.main(fake_args) is None
+            assert register_cloud_guest.main(fake_args, Mock()) is None
 
     @patch('os.makedirs')
     @patch('cloudregister.registerutils.clean_hosts_file')
@@ -131,7 +133,7 @@ class TestRegisterCloudGuest:
             debug=False,
         )
         with raises(SystemExit):
-            register_cloud_guest.main(fake_args)
+            register_cloud_guest.main(fake_args, Mock())
 
     @patch('cloudregister.registerutils.set_registration_completed_flag')
     @patch('cloudregister.registerutils.set_new_registration_flag')
@@ -179,7 +181,7 @@ class TestRegisterCloudGuest:
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
                 with raises(SystemExit) as sys_exit:
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
 
     @patch('cloudregister.registerutils.set_new_registration_flag')
@@ -226,7 +228,7 @@ class TestRegisterCloudGuest:
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
                 with raises(SystemExit) as sys_exit:
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
 
     @patch.object(SMT, 'is_equivalent')
@@ -311,7 +313,7 @@ class TestRegisterCloudGuest:
             ):
                 with raises(SystemExit) as sys_exit:
                     with self._caplog.at_level(logging.DEBUG):
-                        register_cloud_guest.main(fake_args)
+                        register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
         assert 'Configured update server is unresponsive' in self._caplog.text
 
@@ -409,7 +411,7 @@ class TestRegisterCloudGuest:
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
                 with raises(SystemExit) as sys_exit:
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -608,7 +610,7 @@ class TestRegisterCloudGuest:
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
                 with raises(SystemExit) as sys_exit:
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.replace_hosts_entry')
@@ -714,7 +716,7 @@ class TestRegisterCloudGuest:
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
                 with raises(SystemExit) as sys_exit:
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -811,7 +813,7 @@ class TestRegisterCloudGuest:
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
                 with raises(SystemExit) as sys_exit:
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
             assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -915,7 +917,7 @@ class TestRegisterCloudGuest:
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
                 with raises(SystemExit) as sys_exit:
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
             assert 'No registration executable found' in self._caplog.text
             assert sys_exit.value.code == 1
 
@@ -1024,7 +1026,7 @@ class TestRegisterCloudGuest:
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
                 with raises(SystemExit) as sys_exit:
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 0
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -1132,7 +1134,7 @@ class TestRegisterCloudGuest:
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
                 with raises(SystemExit) as sys_exit:
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
         assert 'No products installed on system' in self._caplog.text
         assert sys_exit.value.code == 1
 
@@ -1245,7 +1247,7 @@ class TestRegisterCloudGuest:
                     'cloudregister.registerutils.REGISTRATION_DATA_DIR',
                     new=tdir,
                 ):
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 1
 
     @patch('cloudregister.registerutils.set_proxy')
@@ -1282,10 +1284,8 @@ class TestRegisterCloudGuest:
     @patch('cloudregister.registerutils.deregister_from_update_infrastructure')
     @patch('cloudregister.registerutils.deregister_from_SCC')
     @patch('cloudregister.registerutils.clean_cache')
-    @patch('cloudregister.registerutils.clean_all_standard')
     def test_register_cloud_guest_force_baseprod_registration_failed(
         self,
-        mock_clean_all_standard,
         mock_clean_cache,
         mock_deregister_from_SCC,
         mock_deregister_from_update_infrastructure,
@@ -1373,7 +1373,7 @@ class TestRegisterCloudGuest:
                     'cloudregister.registerutils.REGISTRATION_DATA_DIR',
                     new=tdir,
                 ):
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
         assert 'Baseproduct registration failed' in self._caplog.text
         assert sys_exit.value.code == 1
 
@@ -1529,7 +1529,7 @@ class TestRegisterCloudGuest:
                     'cloudregister.registerutils.REGISTRATION_DATA_DIR',
                     new=tdir,
                 ):
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
         assert (
             'Unable to obtain product information from server "1.2.3.5,None"'
             in self._caplog.text
@@ -1578,10 +1578,8 @@ class TestRegisterCloudGuest:
     @patch('cloudregister.registerutils.deregister_from_update_infrastructure')
     @patch('cloudregister.registerutils.deregister_from_SCC')
     @patch('cloudregister.registerutils.clean_cache')
-    @patch('cloudregister.registerutils.clean_all_standard')
     def test_register_cloud_guest_force_baseprod_extensions_raise(
         self,
-        mock_clean_all_standard,
         mock_clean_cache,
         mock_deregister_from_SCC,
         mock_deregister_from_update_infrastructure,
@@ -1733,7 +1731,7 @@ class TestRegisterCloudGuest:
                     'cloudregister.registerutils.REGISTRATION_DATA_DIR',
                     new=tdir,
                 ):
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 6
 
     @patch('cloudregister.registerutils.set_registration_completed_flag')
@@ -1951,7 +1949,7 @@ class TestRegisterCloudGuest:
             with patch(
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
-                assert register_cloud_guest.main(fake_args) is None
+                assert register_cloud_guest.main(fake_args, Mock()) is None
         assert 'Forced new registration' in self._caplog.text
         assert (
             'Using user specified SMT server:\n\n\t"IP:1.2.3.5"\n\t"'
@@ -2176,7 +2174,7 @@ class TestRegisterCloudGuest:
             with patch(
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
-                assert register_cloud_guest.main(fake_args) is None
+                assert register_cloud_guest.main(fake_args, Mock()) is None
         assert 'Forced new registration' in self._caplog.text
         assert (
             'Using user specified SMT server:\n\n\t"IP:fc00::1"\n\t"'
@@ -2420,7 +2418,7 @@ class TestRegisterCloudGuest:
                 'cloudregister.registercloudguest.REGISTRATION_DATA_DIR',
                 new=tdir,
             ):
-                assert register_cloud_guest.main(fake_args) is None
+                assert register_cloud_guest.main(fake_args, Mock()) is None
 
         assert 'Registration succeeded' in self._caplog.text
         assert (
@@ -2653,7 +2651,7 @@ class TestRegisterCloudGuest:
                         'cloudregister.registerutils.REGISTRATION_DATA_DIR',
                         new=tdir,
                     ):
-                        register_cloud_guest.main(fake_args)
+                        register_cloud_guest.main(fake_args, Mock())
         assert sys_exit.value.code == 0
         assert (
             'Region change detected, registering to new servers'
@@ -3128,9 +3126,35 @@ class TestRegisterCloudGuest:
         mock_deregister_from_update_infrastructure,
         mock_deregister_non_free_extensions,
     ):
+        etc_content = Mock()
+        var_cache_cloudregister_content = Mock()
+        # cleanup with content manager(git)...
+        register_cloud_guest.cleanup(
+            etc_content, var_cache_cloudregister_content
+        )
+        mock_deregister_non_free_extensions.assert_called_once_with()
+        mock_deregister_from_update_infrastructure.assert_called_once_with()
+        mock_deregister_from_SCC.assert_called_once_with()
+        etc_content.cleanup.assert_called_once_with()
+        var_cache_cloudregister_content.cleanup.assert_called_once_with()
+
         # cleanup standard style
         register_cloud_guest.cleanup()
         mock_clean_all_standard.assert_called_once_with()
+
+    def test_reset(self):
+        etc_content = Mock()
+        var_cache_cloudregister_content = Mock()
+        register_cloud_guest.reset(etc_content, var_cache_cloudregister_content)
+        etc_content.reset.assert_called_once_with()
+        var_cache_cloudregister_content.reset.assert_called_once_with()
+
+    def test_done(self):
+        etc_content = Mock()
+        var_cache_cloudregister_content = Mock()
+        register_cloud_guest.done(etc_content, var_cache_cloudregister_content)
+        etc_content.done.assert_called_once_with()
+        var_cache_cloudregister_content.done.assert_called_once_with()
 
     @patch('cloudregister.registerutils._remove_state_file')
     @patch('cloudregister.registerutils.set_registration_completed_flag')
@@ -3359,5 +3383,5 @@ class TestRegisterCloudGuest:
                 'cloudregister.registerutils.REGISTRATION_DATA_DIR', new=tdir
             ):
                 with raises(SystemExit) as sys_exit:
-                    register_cloud_guest.main(fake_args)
+                    register_cloud_guest.main(fake_args, Mock())
                     assert sys_exit.value.code == 1

--- a/test/unit/registerutils_test.py
+++ b/test/unit/registerutils_test.py
@@ -5143,6 +5143,52 @@ export DOCKER_CONFIG=/etc/containers
             in self._caplog.text
         )
 
+    @patch('glob.glob')
+    @patch('os.path.exists')
+    @patch('os.access')
+    @patch('cloudregister.registerutils.exec_subprocess')
+    @patch('cloudregister.registerutils.get_register_cmd')
+    def test_register_product_manage_zypper_files(
+        self,
+        mock_get_register_cmd,
+        mock_exec_subprocess,
+        mock_os_access,
+        mock_os_path_exists,
+        mock_glob,
+    ):
+        glob_results = [
+            # new zypp files and cache data
+            ['some_cache_data'],
+            ['some_repos'],
+            ['some_services'],
+            ['some_credentials'],
+            # exclude_zypp_files
+            [],
+            [],
+            [],
+        ]
+
+        def glob_mock(arg):
+            return glob_results.pop()
+
+        smt = Mock()
+        smt.get_FQDN.return_value = 'some_FQDN'
+        mock_get_register_cmd.return_value = 'SUSEConnect'
+        mock_os_path_exists.return_value = True
+        mock_os_access.return_value = True
+        mock_exec_subprocess.return_value = (b'', b'', 0)
+        mock_glob.side_effect = glob_mock
+
+        utils.etc_content.reset_mock()
+        utils.register_product(smt)
+
+        assert utils.etc_content.manage.call_args_list == [
+            call('/etc/zypp/credentials.d/SCCcredentials'),
+            call('some_credentials'),
+            call('some_services'),
+            call('some_repos'),
+        ]
+
     @patch('cloudregister.registerutils.get_credentials')
     @patch('cloudregister.registerutils.HTTPBasicAuth')
     @patch('cloudregister.registerutils.get_smt_from_store')

--- a/test/unit/smt_test.py
+++ b/test/unit/smt_test.py
@@ -408,7 +408,7 @@ class TestSMT:
         mock_get_cert.return_value = "what a cert"
         smt = SMT(etree.fromstring(smt_data_ipv4))
         with tempfile.TemporaryDirectory() as tmpdirname:
-            smt.write_cert(tmpdirname)
+            smt.write_cert(tmpdirname, Mock())
             certs = glob.glob("%s/*.pem" % tmpdirname)
             assert len(certs) == 1
             assert certs[0] == (


### PR DESCRIPTION
As of today all files created or modified by the client registration in the systems /etc path are more or less unknown. There is no way to differentiate between
modifications done by the registration client and changes done by a user. As we are touching files that are likely to be changed by users e.g. etc/hosts it is handy to put all those under git control. This allows the client to perform the following actions:

* git based restore to the state prior registration on cleanup
* possible detection of file changes done by a user between registration and cleanup
* proper rollback in case of exceptions or interrupts during the registration via python context manager

This feature can be enabled via the --git option
and requires the user to install git beforehand as we cannot force users to install git.
This Fixes #271
