### PR TITLE
Fix credentials cleanup when registration fails

### DIFF
--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -321,6 +321,10 @@ def register_base_product(
                 utils.deregister_non_free_extensions()
                 utils.deregister_from_update_infrastructure()
                 utils.deregister_from_SCC()
+                utils.clean_hosts_file(
+                    registration_target.get_domain_name()
+                )
+                utils.clean_base_credentials()
                 utils.clean_cache()
                 sys.exit(1)
             for smt_srv in region_smt_servers:

--- a/package/cloud-regionsrv-client.spec
+++ b/package/cloud-regionsrv-client.spec
@@ -40,6 +40,7 @@ Patch0:         fix-for-sles12-disable-ipv6.patch
 Patch1:         fix-for-sles12-disable-registry.patch
 # PATCH-FIX-SLES12 fix-for-sles12-no-trans_update.patch
 Patch2:         fix-for-sles12-no-trans_update.patch
+Requires:       sed
 Requires:       SUSEConnect > 0.3.31
 Requires:       ca-certificates
 Requires:       cloud-regionsrv-client-config
@@ -267,6 +268,17 @@ if [ "$1" -gt 1 ] ; then
     %{_sbindir}/createregioninfo
 fi
 fi
+# replace obsolete NCCcredentials with SCCcredentials
+# the following code block is scheduled for deletion end of 2026
+for repo in /etc/zypp/repos.d/*.repo; do
+    test -f "${repo}" && sed -i "s@NCCcredentials@SCCcredentials@g" "${repo}"
+done
+if [ -f /etc/zypp/credentials.d/NCCcredentials ]; then
+    mv \
+        /etc/zypp/credentials.d/NCCcredentials \
+        /etc/zypp/credentials.d/SCCcredentials
+fi
+# enable services
 %service_add_post guestregister.service containerbuild-regionsrv.service
 
 %post license-watcher


### PR DESCRIPTION
Based on the refactored cleanup code this commit fixes the missing credentials cleanup when suseconnect has failed.