### PR TITLE
Consolidate logging messages

### DIFF
--- a/cloudregister/smt.py
+++ b/cloudregister/smt.py
@@ -201,7 +201,7 @@ class SMT:
     # --------------------------------------------------------------------
     def write_cert(self, target_dir):
         """Write the certificate to the given directory"""
-        logging.info('Writing SMT rootCA: %s' % target_dir)
+        logging.debug('Writing SMT rootCA: %s' % target_dir)
         cert = self.get_cert()
         certs_to_write = []
         ipv4 = self.get_ipv4()
@@ -300,7 +300,7 @@ class SMT:
                         logging.warning('Server %s is unreachable' % ip)
                     if cert_res:
                         if cert_res.status_code == 200:
-                            logging.info(
+                            logging.debug(
                                 'Request to %s%s succeeded' %
                                 (cert_url, cert_name)
                             )

--- a/test/unit/smt_test.py
+++ b/test/unit/smt_test.py
@@ -236,8 +236,8 @@ def test_get_cert(
     mock_get_fingerprint.return_value = x509.get_fingerprint('sha1')
     smt = SMT(etree.fromstring(smt_data_ipv46))
     assert smt.get_cert() == response.text
-    assert mock_logging.info.called
-    mock_logging.info.assert_called_with(
+    assert mock_logging.debug.called
+    mock_logging.debug.assert_called_with(
         'Request to http://[fc00::1]/smt.crt succeeded'
     )
 


### PR DESCRIPTION
Several logging messages are considered processing instructions helpful in the log file but not of great help on the console especially on successful registrations. This commit turns a number of message to be debug
information which are listed precisely also with their entry point in code in the log file but not on the console. This Fixes #283