### PR TITLE
Properly set the registration return value indicator on registration success

### DIFF
--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -356,6 +356,7 @@ def register_base_product(
         else:
             log.info('Baseproduct registration complete')
             base_registered = True
+            registration_returncode = 0
             utils.clear_new_registration_flag()
             if args.email or args.reg_code:
                 utils.set_rmt_as_scc_proxy_flag()


### PR DESCRIPTION
In the situation where the initial base product registration against a specific update server failed but a registration of he base product to another update server succeeded we did not set the global registration code indicator to 0 and we retained the return code of the initial failed registration. Improperly indicating that registration had failed.