### PR TITLE
write instance data cache file

### DIFF
--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -34,7 +34,7 @@ import requests
 import sys
 import time
 import urllib.parse
-import uuid
+
 
 from cloudregister.lock import Lock
 from cloudregister.logger import Logger
@@ -390,6 +390,9 @@ def register_base_product(
                         registration_target.get_domain_name()
                     )
                     utils.clean_cache()
+                    # instance data is passed to the registration utility,
+                    # make sure it persists when attempting a retry
+                    instance_data_filepath = utils.write_instance_data()
                     registration_target = smt_srv
                     break
         else:
@@ -750,17 +753,7 @@ def main(args):
         find_alive_registration_target(registration_smt, region_smt_servers)
     )
 
-    # Check if we need to send along any instance data
-    instance_data_filepath = ''
-    instance_data = utils.get_instance_data(cfg)
-    if instance_data:
-        instance_data_filepath = os.path.join(
-            utils.get_state_dir(), str(uuid.uuid4())
-        )
-        inst_data_out = open(instance_data_filepath, 'w')
-        inst_data_out.write(instance_data)
-        inst_data_out.close()
-
+    instance_data_filepath = utils.write_instance_data(cfg)
     if registration_target_found:
         # 1. check/setup the container registry for this target
         if not setup_registry(registration_smt):

--- a/cloudregister/registerutils.py
+++ b/cloudregister/registerutils.py
@@ -32,6 +32,7 @@ import sys
 import time
 import toml
 import yaml
+import uuid
 
 from collections import namedtuple
 from lxml import etree
@@ -2863,6 +2864,24 @@ def set_registry_fqdn_suma(private_registry_fqdn):
 
     # the registry value inside the file has the update server registry FQDN
     return True
+
+
+# ----------------------------------------------------------------------------
+def write_instance_data(cfg=None):
+    if not cfg:
+        cfg = get_config()
+
+    # Check if we need to send along any instance data
+    instance_data_filepath = ''
+    instance_data = get_instance_data(cfg)
+    if instance_data:
+        instance_data_filepath = os.path.join(
+            get_state_dir(), str(uuid.uuid4())
+        )
+        with open(instance_data_filepath, 'w') as inst_data_out:
+            inst_data_out.write(instance_data)
+
+    return instance_data_filepath
 
 
 # ----------------------------------------------------------------------------

--- a/package/fix-for-sles12-disable-ipv6.patch
+++ b/package/fix-for-sles12-disable-ipv6.patch
@@ -1,11 +1,12 @@
 diff --git a/cloudregister/smt.py b/cloudregister/smt.py
-index 62c461a..19c7ebd 100644
+index 55f189f..59cb0e4 100644
 --- a/cloudregister/smt.py
 +++ b/cloudregister/smt.py
-@@ -128,6 +128,7 @@ class SMT:
+@@ -132,6 +132,8 @@ class SMT:
      # --------------------------------------------------------------------
      def get_ipv6(self):
          """Return the IP address"""
++        # Disable for SLE12
 +        return None
          # Before handling ipv6 the IP address was stored in the _ip
          # member. When the SMT object is restored from an old pickeled

--- a/package/fix-for-sles12-disable-registry.patch
+++ b/package/fix-for-sles12-disable-registry.patch
@@ -1,8 +1,8 @@
 diff --git a/cloudregister/registercloudguest.py b/cloudregister/registercloudguest.py
-index fc16c4e..0df0871 100644
+index cf7c372..03e2769 100644
 --- a/cloudregister/registercloudguest.py
 +++ b/cloudregister/registercloudguest.py
-@@ -154,6 +154,8 @@ def setup_registry(registration_target):
+@@ -180,6 +180,8 @@ def setup_registry(registration_target):
      """
      Run the registration process for the container registry
      """
@@ -12,10 +12,10 @@ index fc16c4e..0df0871 100644
          utils.get_credentials_file(registration_target)
      )
 diff --git a/cloudregister/registerutils.py b/cloudregister/registerutils.py
-index 21e55d0..09c85eb 100644
+index 4973b40..5420ef4 100644
 --- a/cloudregister/registerutils.py
 +++ b/cloudregister/registerutils.py
-@@ -29,7 +29,8 @@ import stat
+@@ -30,7 +30,8 @@ import stat
  import subprocess
  import sys
  import time
@@ -23,9 +23,9 @@ index 21e55d0..09c85eb 100644
 +# Disabled on SLE12
 +# import toml
  import yaml
+ import uuid
  
- from collections import namedtuple
-@@ -82,8 +83,9 @@ def add_hosts_entry(smt_server):
+@@ -88,8 +89,9 @@ def add_hosts_entry(smt_server):
          smt_server.get_FQDN(),
          smt_server.get_name(),
      )
@@ -37,7 +37,7 @@ index 21e55d0..09c85eb 100644
  
      with open('/etc/hosts', 'a') as hosts_file:
          hosts_file.write(smt_hosts_entry_comment)
-@@ -980,6 +982,8 @@ def set_container_engines_env_vars():
+@@ -983,6 +985,8 @@ def set_container_engines_env_vars():
  
  # ----------------------------------------------------------------------------
  def get_registry_conf_file(container_path, container):
@@ -46,7 +46,7 @@ index 21e55d0..09c85eb 100644
      registries_conf = {}
      try:
          with open(container_path, 'r') as registries_conf_file:
-@@ -1025,6 +1029,8 @@ def update_bashrc(content, mode):
+@@ -1028,6 +1032,8 @@ def update_bashrc(content, mode):
  # ----------------------------------------------------------------------------
  def clean_registry_setup():
      """Remove the data previously set to make the registry work."""
@@ -55,7 +55,7 @@ index 21e55d0..09c85eb 100644
      smt = get_smt_from_store(_get_registered_smt_file_path())
      private_registry_fqdn = smt.get_registry_FQDN() if smt else ''
      clean_registry_auth(private_registry_fqdn)
-@@ -1294,6 +1300,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
+@@ -1297,6 +1303,8 @@ def clean_registries_conf_docker(private_registry_fqdn):
  # ----------------------------------------------------------------------------
  def write_registries_conf(registries_conf, container_path, container_name):
      """Write registries_conf content to container_path."""

--- a/test/unit/registercloudguest_test.py
+++ b/test/unit/registercloudguest_test.py
@@ -3046,6 +3046,7 @@ class TestRegisterCloudGuest:
         assert 'LTSS registration failed' in self._caplog.text
         assert 'is wrong' in self._caplog.text
 
+    @patch('cloudregister.registerutils.write_instance_data')
     @patch('cloudregister.registerutils.register_product')
     @patch('cloudregister.registerutils.add_hosts_entry')
     @patch('cloudregister.registercloudguest.cleanup')
@@ -3066,6 +3067,7 @@ class TestRegisterCloudGuest:
         mock_cleanup,
         mock_add_hosts_entry,
         mock_register_product,
+        mock_write_instance_data,
     ):
         prod_reg = Mock()
         prod_reg.returncode = 0

--- a/test/unit/registerutils_test.py
+++ b/test/unit/registerutils_test.py
@@ -5220,6 +5220,48 @@ export DOCKER_CONFIG=/etc/containers
             'Unable to remove client registration from SCC' in self._caplog.text
         )
 
+    # ---------------------------------------------------------------------------
+    @patch('cloudregister.registerutils.uuid.uuid4')
+    @patch('cloudregister.registerutils.get_state_dir')
+    @patch('cloudregister.registerutils.get_instance_data')
+    @patch('cloudregister.registerutils.get_config')
+    def test_write_instance_data_present(
+        self,
+        mock_get_config,
+        mock_get_instance_data,
+        mock_get_state_dir,
+        mock_uuid4,
+    ):
+        cfg = configparser.RawConfigParser()
+        cfg.read(data_path + '/regionserverclnt.cfg')
+        mock_get_config.return_value = cfg
+        mock_get_state_dir.return_value = 'foo'
+        mock_get_instance_data.return_value = 'foo'
+        mock_uuid4.return_value = '1-2-3-4'
+        with patch('builtins.open', create=True):
+            assert utils.write_instance_data() == 'foo/1-2-3-4'
+
+    # ---------------------------------------------------------------------------
+    @patch('cloudregister.registerutils.uuid.uuid4')
+    @patch('cloudregister.registerutils.get_state_dir')
+    @patch('cloudregister.registerutils.get_instance_data')
+    @patch('cloudregister.registerutils.get_config')
+    def test_write_instance_data_not_present(
+        self,
+        mock_get_config,
+        mock_get_instance_data,
+        mock_get_state_dir,
+        mock_uuid4,
+    ):
+        cfg = configparser.RawConfigParser()
+        cfg.read(data_path + '/regionserverclnt.cfg')
+        mock_get_config.return_value = cfg
+        mock_get_state_dir.return_value = 'foo'
+        mock_get_instance_data.return_value = None
+        mock_uuid4.return_value = '1-2-3-4'
+        with patch('builtins.open', create=True):
+            assert utils.write_instance_data() == ''
+
 
 # ---------------------------------------------------------------------------
 # Helper functions


### PR DESCRIPTION
## Description

write instance data cache file

when a registration attempt to an update infrastructure server fails,
the clean_cache method is invoked, cleaning the whole cache directory
causing the subsequent registration attempt by a sibling server to
fail as the file is not present

write the instance data if it's not in the cache directory

This Fixes [bsc#1265930](https://bugzilla.suse.com/show_bug.cgi?id=1265930)

## How to test

on a regular instance, i.e. `suse-sles-15-sp6-byos-v20260519-hvm-ssd-x86_64` run the following commands:

```bash 
sudo registercloudguest -r XXX               # version 10.5.2   
sudo zypper patch && zypper update
sudo zypper ref && zypper up
sudo registercloudguest -r XXX --force-new   # version 11.0.2
```

when registration fails on the first attempt it produces the following output
```bash
2026-05-20 16:43:44,700: ERROR: Registration with ('52.28.214.37', '2a05:d014:9a2:8402:fa7d:8cad:1b49:aa6a') failed. Trying ('54.93.130.182', '2a05:d014:9a2:8400:5dbc:7482:ef44:826f')
2026-05-20 16:43:45,130: ERROR: Registration with ('54.93.130.182', '2a05:d014:9a2:8400:5dbc:7482:ef44:826f') failed. Trying ('54.93.131.24', '2a05:d014:9a2:8401:29e0:3e5f:84a:1f30')
2026-05-20 16:43:45,405: ERROR: Baseproduct registration failed
2026-05-20 16:43:45,406: ERROR: Registering system to registration proxy https://smt-ec2.susecloud.net
SUSEConnect error: open /var/cache/cloudregister/dbf21ceb-cd55-4627-a9c2-9132aaac000b: no such file or directory
```

## Change Type

- [X] **Bug Fix** (a non-breaking change which fixes an issue)
- [ ] **New Feature** (a non-breaking change which adds new functionality)
- [ ] **Documentation Update** (a change which only updates documentation)