### PR TITLE
create the state directory when populating the cache

### DIFF
--- a/cloudregister/registerutils.py
+++ b/cloudregister/registerutils.py
@@ -2112,8 +2112,7 @@ def refresh_zypper_pid_cache():
 # ----------------------------------------------------------------------------
 def set_as_current_smt(smt):
     """Store the given SMT as the current SMT server."""
-    if not os.path.exists(get_state_dir()):
-        os.system('mkdir -p %s' % get_state_dir())
+    create_state_dir()
     store_smt_data(_get_registered_smt_file_path(), smt)
 
 

--- a/cloudregister/registerutils.py
+++ b/cloudregister/registerutils.py
@@ -140,10 +140,7 @@ def clean_cache():
     if os.path.isdir(REGISTRATION_DATA_DIR):
         shutil.rmtree(REGISTRATION_DATA_DIR)
         # Python 3.4 compatibility does not have "exist_ok"
-        try:
-            Path(REGISTRATION_DATA_DIR).mkdir(parents=True)
-        except FileExistsError:
-            pass
+        create_state_dir()
 
 
 # ----------------------------------------------------------------------------
@@ -2437,6 +2434,14 @@ def get_suma_registry_content():
     return {}, True
 
 
+# ----------------------------------------------------------------------------
+def create_state_dir():
+    try:
+        Path(get_state_dir()).mkdir(parents=True)
+    except FileExistsError:
+        pass
+
+
 # Private
 # ----------------------------------------------------------------------------
 def _check_ip_access(ips_addresses):
@@ -2607,6 +2612,7 @@ def _populate_srv_cache():
     log.debug('Populating server cache')
     region_smt_data = fetch_smt_data(cfg, proxies, True)
     cnt = 1
+    create_state_dir()
     for child in region_smt_data:
         update_server = smt.SMT(child)
         server_cache_file_name = AVAILABLE_SMT_SERVER_DATA_FILE_NAME % cnt

--- a/cloudregister/registerutils.py
+++ b/cloudregister/registerutils.py
@@ -139,7 +139,6 @@ def clean_all_standard():
 def clean_cache():
     if os.path.isdir(REGISTRATION_DATA_DIR):
         shutil.rmtree(REGISTRATION_DATA_DIR)
-        # Python 3.4 compatibility does not have "exist_ok"
         create_state_dir()
 
 
@@ -2436,6 +2435,7 @@ def get_suma_registry_content():
 
 # ----------------------------------------------------------------------------
 def create_state_dir():
+    # Python 3.4 compatibility does not have "exist_ok"
     try:
         Path(get_state_dir()).mkdir(parents=True)
     except FileExistsError:

--- a/test/unit/registerutils_test.py
+++ b/test/unit/registerutils_test.py
@@ -3342,6 +3342,7 @@ class TestRegisterUtils:
         mock_glob.return_value = []
         assert utils._has_credentials('foo') is False
 
+    @patch('cloudregister.registerutils.create_state_dir')
     @patch('cloudregister.registerutils.store_smt_data')
     @patch('cloudregister.registerutils.fetch_smt_data')
     @patch('cloudregister.registerutils.get_config')
@@ -3352,6 +3353,7 @@ class TestRegisterUtils:
         mock_get_config,
         mock_fetch_smt_data,
         mock_store_smt_data,
+        mock_create_state_dir,
     ):
         mock_set_proxy.return_value = True
         mock_get_config.return_value = get_test_config()


### PR DESCRIPTION
when populating the cache, the method writes to the state directory and fails because the state directory does not exist

add a method to create the state directory

This Fixes bsc#1267739