### PR TITLE
Add timeout and DNS validation to dataProvider execution

### DIFF
--- a/cloudregister/registerutils.py
+++ b/cloudregister/registerutils.py
@@ -399,12 +399,13 @@ def enable_repository(repo_name):
 
 
 # ----------------------------------------------------------------------------
-def exec_subprocess(cmd, tolog=True):
+def exec_subprocess(cmd, tolog=True, timeout=None):
     """
     Execute the given command as a subprocess (blocking)
     Returns a tuple list:
         (binary_stdout, binary_stderr, exitcode)
         A -1 exitcode indicates an OSError at command invocation
+        A -2 exitcode indicates a timeout occurred
     """
     stdout = b''
     stderr = b''
@@ -415,8 +416,13 @@ def exec_subprocess(cmd, tolog=True):
         proc = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
-        stdout, stderr = proc.communicate()
+        stdout, stderr = proc.communicate(timeout=timeout)
         rcode = proc.returncode
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        stdout, stderr = proc.communicate()
+        rcode = -2
+        log.warning('EXEC timeout after {} seconds: {}'.format(timeout, cmd))
     except OSError as issue:
         log.debug('EXEC failed with: {}'.format(issue))
     return (stdout, stderr, rcode)
@@ -1454,9 +1460,32 @@ def get_instance_data(config):
                     errMsg = 'Could not find configured dataProvider: %s' % cmd
                     log.error(errMsg)
             if os.access(cmd, os.X_OK):
+                # Validate DNS resolution for URLs in the command
+                url_match = re.search(r'https?://([^\s/:]+)', instance_data_cmd)
+                if url_match:
+                    domain = url_match.group(1)
+                    try:
+                        socket.gethostbyname(domain)
+                        log.debug('DNS validation passed for domain: %s' % domain)
+                    except socket.gaierror:
+                        warn_msg = 'Domain "%s" in dataProvider does not resolve. ' % domain
+                        warn_msg += 'Skipping instance data collection.'
+                        log.warning(warn_msg)
+                        # Skip execution and return early with empty data
+                        inst_data = ''
+                        repo_format = '<repoformat>plugin:susecloud</repoformat>\n'
+                        return inst_data + repo_format
+
+                # Execute with 30 second timeout to prevent indefinite hangs
                 instance_data, errors, returncode = exec_subprocess(
-                    instance_data_cmd.split()
+                    instance_data_cmd.split(),
+                    timeout=30
                 )
+                if returncode == -2:
+                    # Timeout occurred
+                    warn_msg = 'dataProvider command timed out after 30 seconds. '
+                    warn_msg += 'Instance data collection failed.'
+                    log.warning(warn_msg)
                 if errors:
                     errMsg = 'Data collected from stderr for instance '
                     errMsg += 'data collection "%s"' % errors.decode()


### PR DESCRIPTION
## Problem
The `registercloudguest` command hangs indefinitely when the domain configured in 
`dataProvider` (e.g., `smt-gce.susecloud.net`) does not resolve or the metadata 
service is unreachable. This causes registration failures in cloud environments, 
particularly on GCE BYOS instances.

## Solution
This PR adds two safeguards to prevent indefinite hangs:
1. **DNS Validation**: Check if domains in dataProvider URLs resolve before execution
   - If NXDOMAIN, skip execution and log warning
   - Allows registration to continue without instance metadata
2. **Execution Timeout**: Add 30-second timeout to dataProvider command execution
   - Prevents indefinite hangs if metadata service is slow/unreachable
   - Returns exit code -2 on timeout for better error handling

## :construction: Testing *WIP*
Tested on GCE instances where `smt-gce.susecloud.net` does not resolve. Without this 
fix, `registercloudguest` hangs indefinitely. With this fix, it logs a warning and 
continues registration successfully.

## Related Issues
- poo#202485 - registercloudguest hangs with "already running" error
- bsc#1261908 - guestregister.service failures on SLES 16 GCE