### PR TITLE
Fix handling of registration returncode

### DIFF
--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -81,6 +81,7 @@ def register_modules(
     regcode='',
     registered=[],
     failed=[],
+    failed_undetermined=[],
     returncode=0,
 ):
     """Register modules obeying dependencies
@@ -105,6 +106,7 @@ def register_modules(
                 regcode,
                 registered,
                 failed,
+                failed_undetermined,
                 returncode,
             )
             continue
@@ -158,6 +160,7 @@ def register_modules(
                             triplet, returncode
                         )
                     )
+                    failed_undetermined.append(triplet)
             else:
                 log.info('Registration of {} succeeded'.format(triplet))
                 registered.append(triplet)
@@ -170,6 +173,7 @@ def register_modules(
             regcode,
             registered,
             failed,
+            failed_undetermined,
             returncode,
         )
 
@@ -837,13 +841,15 @@ def main(args):
 
     extensions = get_extensions(registration_target)
     failed_extensions = []
-    modules_returncode = register_modules(
+    failed_extensions_undetermined = []
+    register_modules(
         extensions,
         products,
         registration_target,
         instance_data_filepath,
         args.reg_code,
         failed=failed_extensions,
+        failed_undetermined=failed_extensions_undetermined,
         returncode=0,
     )
     if os.path.exists(instance_data_filepath):
@@ -858,27 +864,34 @@ def main(args):
 
     log.info('Registration succeeded')
 
-    if modules_returncode:
+    if failed_extensions:
         # Module registration issues do not invalidate the registration
         # of the system. The affected modules can be registered at a
         # later point in time
-        log.warning(
-            'Module registration failed(repository), see {0} for '
-            'details'.format(LOG_FILE)
-        )
-
-    if failed_extensions:
         msg = 'There are products that were not registered because they need '
         msg += 'an additional registration code, to register them please run '
-        msg += 'the following command(s): '
+        msg += 'the following command(s):\n'
 
-        activate_prod_cmd = 'SUSEConnect -p {} -r ADDITIONAL REGCODE'
+        activate_prod_cmd = 'SUSEConnect -p {} -r ADDITIONAL REGCODE\n'
         if utils.is_transactional_system():
             activate_prod_cmd = 'transactional-update register -p {} '
-            activate_prod_cmd += '-r ADDITIONAL REGCODE'
+            activate_prod_cmd += '-r ADDITIONAL REGCODE\n'
 
         for failed_extension in failed_extensions:
             msg += activate_prod_cmd.format(failed_extension)
+
+        log.warning(msg)
+
+    if failed_extensions_undetermined:
+        # There are module registrations with an undetermined error code
+        # Report this as a warning to the user.
+        msg = 'Following module registration(s) failed '
+        msg += 'with an undetermined error code, see {0} for details:\n'.format(
+            LOG_FILE
+        )
+
+        for failed_extension in failed_extensions_undetermined:
+            msg += '{}\n'.format(failed_extension)
 
         log.warning(msg)
 

--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -146,7 +146,7 @@ def register_modules(
                     'registration code' in error_message.lower()
                     or 'system credentials' in error_message.lower()
                 ):
-                    log.debug(
+                    log.warning(
                         '\tModule registration unsuccesful: {} code {}'.format(
                             error_message, returncode
                         )
@@ -155,7 +155,7 @@ def register_modules(
                 else:
                     # Zypper sets codes that do not indicate registration
                     # failure but the registration is not clean
-                    log.debug(
+                    log.warning(
                         '\tModule registration status for {} undetermined: code {}'.format(
                             triplet, returncode
                         )

--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -868,17 +868,19 @@ def main(args):
         )
 
     if failed_extensions:
-        log.warning(
-            'There are products that were not registered because they need '
-            'an additional registration code, to register them please run '
-            'the following command:'
-        )
+        msg = 'There are products that were not registered because they need '
+        msg += 'an additional registration code, to register them please run '
+        msg += 'the following command(s): '
+
         activate_prod_cmd = 'SUSEConnect -p {} -r ADDITIONAL REGCODE'
         if utils.is_transactional_system():
             activate_prod_cmd = 'transactional-update register -p {} '
             activate_prod_cmd += '-r ADDITIONAL REGCODE'
+
         for failed_extension in failed_extensions:
-            log.error(activate_prod_cmd.format(failed_extension))
+            msg += activate_prod_cmd.format(failed_extension)
+
+        log.warning(msg)
 
     # Enable Nvidia repo if repo(s) are configured
     # and destination can be reached

--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -70,7 +70,6 @@ log = Logger.get_logger()
 requests.packages.urllib3.disable_warnings(
     requests.packages.urllib3.exceptions.InsecureRequestWarning
 )
-registration_returncode = 0
 
 
 # ----------------------------------------------------------------------------
@@ -82,14 +81,19 @@ def register_modules(
     regcode='',
     registered=[],
     failed=[],
+    returncode=0,
 ):
-    """Register modules obeying dependencies"""
-    global registration_returncode
+    """Register modules obeying dependencies
+
+    The given returncode is the registration status of the modules
+    registered so far. It is updated by the registrations this call
+    performs and returned to the caller
+    """
     for extension in extensions:
         # If the extension is recommended it gets installed with the
         # baseproduct registration. No need to run another registration
         if extension.get('recommended'):
-            register_modules(
+            returncode = register_modules(
                 extension.get('extensions'),
                 products,
                 registration_target,
@@ -97,6 +101,7 @@ def register_modules(
                 regcode,
                 registered,
                 failed,
+                returncode,
             )
             continue
 
@@ -124,12 +129,12 @@ def register_modules(
                 ZYPPER_UNKNOWN_ERROR,
             )
             if prod_reg.returncode:
-                registration_returncode = prod_reg.returncode
+                returncode = prod_reg.returncode
                 # Older versions of SUSEConnect wrote error messages to stdout
                 error_message = prod_reg.output
                 if not error_message:
                     error_message = prod_reg.error
-                if registration_returncode in reg_fail_codes and (
+                if returncode in reg_fail_codes and (
                     'registration code' in error_message.lower()
                     or 'system credentials' in error_message.lower()
                 ):
@@ -143,7 +148,7 @@ def register_modules(
                     # do not fail the system registration if we end up
                     # missing a specific module, it can always be added
                     # later.
-                    registration_returncode = 0
+                    returncode = 0
                 else:
                     # Zypper sets codes that do not indicate registration
                     # failure but the registration is not clean
@@ -154,7 +159,7 @@ def register_modules(
                 log.info('Registration of {} succeeded'.format(triplet))
                 registered.append(triplet)
 
-        register_modules(
+        returncode = register_modules(
             extension.get('extensions'),
             products,
             registration_target,
@@ -162,7 +167,10 @@ def register_modules(
             regcode,
             registered,
             failed,
+            returncode,
         )
+
+    return returncode
 
 
 # ----------------------------------------------------------------------------
@@ -332,7 +340,6 @@ def register_base_product(
     registration_target, instance_data_filepath, args, region_smt_servers
 ):
     """Register the base product and return the RMT update server registered."""
-    global registration_returncode
     base_registered = False
     failed_smts = []
     while not base_registered:
@@ -344,12 +351,11 @@ def register_base_product(
             instance_data_filepath=instance_data_filepath,
         )
         if prod_reg.returncode:
-            registration_returncode = prod_reg.returncode
             # Even on error SUSEConnect writes messages to stdout, go figure
             error_message = prod_reg.output
             failed_smts.append(registration_target.get_ipv4())
             if len(failed_smts) == len(region_smt_servers) or (
-                registration_returncode == SERVER_GENERAL_ERROR
+                prod_reg.returncode == SERVER_GENERAL_ERROR
                 and 'registration code' in error_message.lower()
                 and args.reg_code
             ):
@@ -398,7 +404,6 @@ def register_base_product(
         else:
             log.debug('Baseproduct registration complete')
             base_registered = True
-            registration_returncode = 0
             utils.clear_new_registration_flag()
             if args.email or args.reg_code:
                 utils.set_rmt_as_scc_proxy_flag()
@@ -621,7 +626,6 @@ argparse.add_argument('-v', '--version', action='version', version=__version__)
 
 def main(args):
     log.debug('registercloudguest {}'.format(__version__))
-    global registration_returncode  # noqa: F824
     # Create our cache dir, we can nolonger handle this in the package.
     # Packaging content outside /usr and /etc is verboten even if we are
     # not really packaging any content
@@ -810,7 +814,7 @@ def main(args):
     )
     extensions = get_extensions(registration_target)
     failed_extensions = []
-    register_modules(
+    registration_returncode = register_modules(
         extensions,
         products,
         registration_target,

--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -368,16 +368,11 @@ def register_base_product(
                 # there are no more RMT servers to try or
                 # registration failed because of an invalid reg code
                 # and the SCC response will not change, independently
-                # of the RMT sibling selected
+                # of the RMT sibling selected. The caller handles the
+                # return code and takes care of the cleanup
                 log.error('Baseproduct registration failed')
                 log.error(error_message)
-                utils.deregister_non_free_extensions()
-                utils.deregister_from_update_infrastructure()
-                utils.deregister_from_SCC()
-                utils.clean_hosts_file(registration_target.get_domain_name())
-                utils.clean_base_credentials()
-                utils.clean_cache()
-                sys.exit(1)
+                break
             for smt_srv in region_smt_servers:
                 target_smt_ipv4 = registration_target.get_ipv4()
                 target_smt_ipv6 = registration_target.get_ipv6()
@@ -816,34 +811,48 @@ def main(args):
         sys.exit(1)
 
     # Register the base product first
-    registration_target, registration_returncode = register_base_product(
+    registration_target, base_returncode = register_base_product(
         registration_target, instance_data_filepath, args, region_smt_servers
     )
+    if base_returncode:
+        # Without the base product no other product can be registered,
+        # this is fatal
+        if os.path.exists(instance_data_filepath):
+            os.unlink(instance_data_filepath)
+        utils.deregister_non_free_extensions()
+        utils.deregister_from_update_infrastructure()
+        utils.deregister_from_SCC()
+        utils.clean_hosts_file(registration_target.get_domain_name())
+        utils.clean_base_credentials()
+        utils.clean_cache()
+        log.error(
+            'Registration failed(baseproduct), see {0} for details'.format(
+                LOG_FILE
+            )
+        )
+        sys.exit(base_returncode)
+
     extensions = get_extensions(registration_target)
     failed_extensions = []
-    registration_returncode = register_modules(
+    modules_returncode = register_modules(
         extensions,
         products,
         registration_target,
         instance_data_filepath,
         args.reg_code,
         failed=failed_extensions,
-        returncode=registration_returncode,
     )
     if os.path.exists(instance_data_filepath):
         os.unlink(instance_data_filepath)
 
-    if registration_returncode:
-        utils.deregister_non_free_extensions()
-        utils.deregister_from_update_infrastructure()
-        utils.deregister_from_SCC()
-        utils.clean_cache()
+    if modules_returncode:
+        # Module registration issues do not invalidate the registration
+        # of the system. The affected modules can be registered at a
+        # later point in time
         log.error(
-            'Registration failed(repository), see {0} for details'.format(
-                LOG_FILE
-            )
+            'Module registration failed(repository), see {0} for '
+            'details'.format(LOG_FILE)
         )
-        sys.exit(registration_returncode)
 
     # Setup container registry
     if not setup_registry(registration_target):

--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -135,11 +135,12 @@ def register_modules(
             if prod_reg.returncode:
                 # module registration has failed, set this returncode
                 returncode = prod_reg.returncode
+
                 # Older versions of SUSEConnect wrote error messages to stdout
                 error_message = prod_reg.output
                 if not error_message:
                     error_message = prod_reg.error
-                if returncode in reg_fail_codes and (
+                if prod_reg.returncode in reg_fail_codes and (
                     'registration code' in error_message.lower()
                     or 'system credentials' in error_message.lower()
                 ):

--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -85,9 +85,13 @@ def register_modules(
 ):
     """Register modules obeying dependencies
 
-    The given returncode is the registration status of the modules
-    registered so far. It is updated by the registrations this call
-    performs and returned to the caller
+    The given returncode is the failed registration status of the
+    modules registered so far. It is recursively updated in case a
+    module registrations fails. The very first call of register_modules()
+    is expected to run without a returncode set, or explicitly set to 0,
+    such that the final returncode from register_modules is either 0
+    (if all module registrations succeeded) or the failed return code
+    from the last module that has failed the registration.
     """
     for extension in extensions:
         # If the extension is recommended it gets installed with the
@@ -129,6 +133,7 @@ def register_modules(
                 ZYPPER_UNKNOWN_ERROR,
             )
             if prod_reg.returncode:
+                # module registration has failed, set this returncode
                 returncode = prod_reg.returncode
                 # Older versions of SUSEConnect wrote error messages to stdout
                 error_message = prod_reg.output
@@ -139,22 +144,19 @@ def register_modules(
                     or 'system credentials' in error_message.lower()
                 ):
                     log.error(
-                        '\tModule registration unsuccesful: {}'.format(
-                            error_message
+                        '\tModule registration unsuccesful: {} code {}'.format(
+                            error_message, returncode
                         )
                     )
                     failed.append(triplet)
-                    # Module registration is a best effort approach. We
-                    # do not fail the system registration if we end up
-                    # missing a specific module, it can always be added
-                    # later.
-                    returncode = 0
                 else:
                     # Zypper sets codes that do not indicate registration
                     # failure but the registration is not clean
-                    warn_msg = '\tModule registration status for '
-                    warn_msg += '{} undetermined'.format(triplet)
-                    log.warning(warn_msg)
+                    log.warning(
+                        '\tModule registration status for {} undetermined: code {}'.format(
+                            triplet, returncode
+                        )
+                    )
             else:
                 log.info('Registration of {} succeeded'.format(triplet))
                 registered.append(triplet)
@@ -841,6 +843,7 @@ def main(args):
         instance_data_filepath,
         args.reg_code,
         failed=failed_extensions,
+        returncode=0,
     )
     if os.path.exists(instance_data_filepath):
         os.unlink(instance_data_filepath)

--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -339,7 +339,12 @@ def setup_ltss_registration(
 def register_base_product(
     registration_target, instance_data_filepath, args, region_smt_servers
 ):
-    """Register the base product and return the RMT update server registered."""
+    """Register the base product
+
+    Return the RMT update server registered with and the return code
+    of the base product registration
+    """
+    returncode = 0
     base_registered = False
     failed_smts = []
     while not base_registered:
@@ -351,11 +356,12 @@ def register_base_product(
             instance_data_filepath=instance_data_filepath,
         )
         if prod_reg.returncode:
+            returncode = prod_reg.returncode
             # Even on error SUSEConnect writes messages to stdout, go figure
             error_message = prod_reg.output
             failed_smts.append(registration_target.get_ipv4())
             if len(failed_smts) == len(region_smt_servers) or (
-                prod_reg.returncode == SERVER_GENERAL_ERROR
+                returncode == SERVER_GENERAL_ERROR
                 and 'registration code' in error_message.lower()
                 and args.reg_code
             ):
@@ -404,11 +410,12 @@ def register_base_product(
         else:
             log.debug('Baseproduct registration complete')
             base_registered = True
+            returncode = 0
             utils.clear_new_registration_flag()
             if args.email or args.reg_code:
                 utils.set_rmt_as_scc_proxy_flag()
 
-    return registration_target
+    return registration_target, returncode
 
 
 # ----------------------------------------------------------------------------
@@ -809,7 +816,7 @@ def main(args):
         sys.exit(1)
 
     # Register the base product first
-    registration_target = register_base_product(
+    registration_target, registration_returncode = register_base_product(
         registration_target, instance_data_filepath, args, region_smt_servers
     )
     extensions = get_extensions(registration_target)
@@ -821,6 +828,7 @@ def main(args):
         instance_data_filepath,
         args.reg_code,
         failed=failed_extensions,
+        returncode=registration_returncode,
     )
     if os.path.exists(instance_data_filepath):
         os.unlink(instance_data_filepath)

--- a/cloudregister/registercloudguest.py
+++ b/cloudregister/registercloudguest.py
@@ -143,7 +143,7 @@ def register_modules(
                     'registration code' in error_message.lower()
                     or 'system credentials' in error_message.lower()
                 ):
-                    log.error(
+                    log.debug(
                         '\tModule registration unsuccesful: {} code {}'.format(
                             error_message, returncode
                         )
@@ -152,7 +152,7 @@ def register_modules(
                 else:
                     # Zypper sets codes that do not indicate registration
                     # failure but the registration is not clean
-                    log.warning(
+                    log.debug(
                         '\tModule registration status for {} undetermined: code {}'.format(
                             triplet, returncode
                         )
@@ -848,15 +848,6 @@ def main(args):
     if os.path.exists(instance_data_filepath):
         os.unlink(instance_data_filepath)
 
-    if modules_returncode:
-        # Module registration issues do not invalidate the registration
-        # of the system. The affected modules can be registered at a
-        # later point in time
-        log.error(
-            'Module registration failed(repository), see {0} for '
-            'details'.format(LOG_FILE)
-        )
-
     # Setup container registry
     if not setup_registry(registration_target):
         cleanup()
@@ -865,6 +856,15 @@ def main(args):
     utils.set_registration_completed_flag()
 
     log.info('Registration succeeded')
+
+    if modules_returncode:
+        # Module registration issues do not invalidate the registration
+        # of the system. The affected modules can be registered at a
+        # later point in time
+        log.warning(
+            'Module registration failed(repository), see {0} for '
+            'details'.format(LOG_FILE)
+        )
 
     if failed_extensions:
         log.warning(

--- a/test/unit/registercloudguest_test.py
+++ b/test/unit/registercloudguest_test.py
@@ -1748,7 +1748,7 @@ class TestRegisterCloudGuest:
                 new=tdir,
             ):
                 register_cloud_guest.main(fake_args)
-        assert 'Module registration failed(repository)' in self._caplog.text
+        assert 'Following module registration(s) failed' in self._caplog.text
         assert 'Registration succeeded' in self._caplog.text
         mock_set_registration_completed_flag.assert_called_once_with()
         mock_deregister_from_SCC.assert_not_called()

--- a/test/unit/registercloudguest_test.py
+++ b/test/unit/registercloudguest_test.py
@@ -3145,12 +3145,16 @@ class TestRegisterCloudGuest:
         commandline_args = Mock()
         region_smt_servers = [Mock(), Mock()]
         # Test success case
-        register_cloud_guest.register_base_product(
-            registration_target,
-            instance_data_filepath,
-            commandline_args,
-            region_smt_servers,
+        registered_target, returncode = (
+            register_cloud_guest.register_base_product(
+                registration_target,
+                instance_data_filepath,
+                commandline_args,
+                region_smt_servers,
+            )
         )
+        assert registered_target == registration_target
+        assert returncode == 0
         assert 'Baseproduct registration complete' in self._caplog.text
         mock_clear_new_registration_flag.assert_called_once_with()
         mock_set_rmt_as_scc_proxy_flag.assert_called_once_with()

--- a/test/unit/registercloudguest_test.py
+++ b/test/unit/registercloudguest_test.py
@@ -1538,7 +1538,6 @@ class TestRegisterCloudGuest:
         assert sys_exit.value.code == 1
 
     @patch('cloudregister.registerutils.set_proxy')
-    @patch('cloudregister.registercloudguest.registration_returncode', 0)
     @patch('os.unlink')
     @patch('cloudregister.registerutils.get_credentials_file')
     @patch('cloudregister.registerutils.get_credentials')
@@ -1744,7 +1743,6 @@ class TestRegisterCloudGuest:
     @patch('cloudregister.registerutils.get_repo_url')
     @patch('cloudregister.registerutils.find_repos')
     @patch('cloudregister.registerutils.has_nvidia_support')
-    @patch('cloudregister.registercloudguest.registration_returncode', 0)
     @patch('os.unlink')
     @patch('cloudregister.registerutils.get_credentials_file')
     @patch('cloudregister.registerutils.get_credentials')
@@ -1970,7 +1968,6 @@ class TestRegisterCloudGuest:
     @patch('cloudregister.registerutils.get_repo_url')
     @patch('cloudregister.registerutils.find_repos')
     @patch('cloudregister.registerutils.has_nvidia_support')
-    @patch('cloudregister.registercloudguest.registration_returncode', 0)
     @patch('os.unlink')
     @patch('cloudregister.registerutils.get_credentials_file')
     @patch('cloudregister.registerutils.get_credentials')
@@ -2202,7 +2199,6 @@ class TestRegisterCloudGuest:
     @patch('cloudregister.registerutils.get_repo_url')
     @patch('cloudregister.registerutils.find_repos')
     @patch('cloudregister.registerutils.has_nvidia_support')
-    @patch('cloudregister.registercloudguest.registration_returncode', 0)
     @patch('os.unlink')
     @patch('cloudregister.registerutils.get_credentials_file')
     @patch('cloudregister.registerutils.get_credentials')
@@ -2440,7 +2436,6 @@ class TestRegisterCloudGuest:
     @patch('cloudregister.registerutils.get_repo_url')
     @patch('cloudregister.registerutils.find_repos')
     @patch('cloudregister.registerutils.has_nvidia_support')
-    @patch('cloudregister.registercloudguest.registration_returncode', 0)
     @patch('os.unlink')
     @patch('cloudregister.registerutils.get_credentials_file')
     @patch('cloudregister.registerutils.get_credentials')
@@ -2689,8 +2684,16 @@ class TestRegisterCloudGuest:
                 'available': True,
             }
         ]
-        register_cloud_guest.register_modules(
-            extensions, ['SLES-LTSS/15.4/x86_64'], 'reg_target', 'path', [], []
+        assert (
+            register_cloud_guest.register_modules(
+                extensions,
+                ['SLES-LTSS/15.4/x86_64'],
+                'reg_target',
+                'path',
+                [],
+                [],
+            )
+            == 0
         )
 
     @patch('cloudregister.registerutils.register_product')
@@ -2724,9 +2727,61 @@ class TestRegisterCloudGuest:
                 'available': True,
             }
         ]
-        register_cloud_guest.register_modules(
-            extensions, ['SLES-LTSS/15.4/x86_64'], 'reg_target', 'path', [], []
+        assert (
+            register_cloud_guest.register_modules(
+                extensions,
+                ['SLES-LTSS/15.4/x86_64'],
+                'reg_target',
+                'path',
+                [],
+                [],
+            )
+            == 0
         )
+
+    @patch('cloudregister.registerutils.register_product')
+    def test_register_modules_undetermined(self, mock_register_product):
+        prod_reg_type = namedtuple(
+            'prod_reg_type', ['returncode', 'output', 'error']
+        )
+
+        mock_register_product.return_value = prod_reg_type(
+            returncode=67, output='', error='some other problem'
+        )
+        extensions = [
+            {
+                'id': 23,
+                'name': 'SUSE Linux Enterprise Server LTSS',
+                'identifier': 'SLES-LTSS',
+                'former_identifier': 'SLES-LTSS',
+                'version': '15.4',
+                'release_type': None,
+                'release_stage': 'released',
+                'arch': 'x86_64',
+                'friendly_name': 'SUSE Linux Enterprise Server LTSS 15 SP4 x86_64',
+                'product_class': 'SLES15-SP4-LTSS-X86',
+                'free': False,
+                'repositories': [],
+                'product_type': 'extension',
+                'extensions': [],
+                'recommended': False,
+                'available': True,
+            }
+        ]
+        # the registration status of a failure that is not related to
+        # the registration code is handed back to the caller
+        assert (
+            register_cloud_guest.register_modules(
+                extensions,
+                ['SLES-LTSS/15.4/x86_64'],
+                'reg_target',
+                'path',
+                [],
+                [],
+            )
+            == 67
+        )
+        assert 'undetermined' in self._caplog.text
 
     @patch('cloudregister.registerutils.is_registry_registered')
     @patch('cloudregister.registerutils.get_credentials_file')
@@ -3142,7 +3197,6 @@ class TestRegisterCloudGuest:
     @patch('cloudregister.registerutils.get_repo_url')
     @patch('cloudregister.registerutils.find_repos')
     @patch('cloudregister.registerutils.has_nvidia_support')
-    @patch('cloudregister.registercloudguest.registration_returncode', 0)
     @patch('os.unlink')
     @patch('cloudregister.registerutils.get_credentials_file')
     @patch('cloudregister.registerutils.get_credentials')

--- a/test/unit/registercloudguest_test.py
+++ b/test/unit/registercloudguest_test.py
@@ -1248,6 +1248,7 @@ class TestRegisterCloudGuest:
                     register_cloud_guest.main(fake_args)
         assert sys_exit.value.code == 1
 
+    @patch('os.unlink')
     @patch('cloudregister.registerutils.set_proxy')
     @patch('cloudregister.registerutils.register_product')
     @patch('cloudregister.registerutils.import_smt_cert')
@@ -1320,6 +1321,7 @@ class TestRegisterCloudGuest:
         mock_import_smt_cert,
         mock_register_product,
         mock_set_proxy,
+        mock_os_unlink,
     ):
         smt_data_ipv46 = dedent(
             '''\
@@ -1375,7 +1377,14 @@ class TestRegisterCloudGuest:
                 ):
                     register_cloud_guest.main(fake_args)
         assert 'Baseproduct registration failed' in self._caplog.text
-        assert sys_exit.value.code == 1
+        assert 'Registration failed(baseproduct)' in self._caplog.text
+        # the process exits with the return code of the registration
+        assert sys_exit.value.code == 67
+        # the caller of register_base_product cleans up
+        mock_deregister_non_free_extensions.assert_called_once_with()
+        mock_deregister_from_update_infrastructure.assert_called_once_with()
+        mock_deregister_from_SCC.assert_called_once_with()
+        mock_clean_cache.assert_called_once_with()
 
     @patch('cloudregister.registerutils._remove_state_file')
     @patch('cloudregister.registerutils.set_proxy')
@@ -1537,6 +1546,8 @@ class TestRegisterCloudGuest:
         assert 'Unable to register modules, exiting.' in self._caplog.text
         assert sys_exit.value.code == 1
 
+    @patch('cloudregister.registerutils.set_registration_completed_flag')
+    @patch('cloudregister.registerutils.has_nvidia_support')
     @patch('cloudregister.registerutils.set_proxy')
     @patch('os.unlink')
     @patch('cloudregister.registerutils.get_credentials_file')
@@ -1578,7 +1589,7 @@ class TestRegisterCloudGuest:
     @patch('cloudregister.registerutils.deregister_from_SCC')
     @patch('cloudregister.registerutils.clean_cache')
     @patch('cloudregister.registerutils.clean_all_standard')
-    def test_register_cloud_guest_force_baseprod_extensions_raise(
+    def test_register_cloud_guest_force_module_registration_failed(
         self,
         mock_clean_all_standard,
         mock_clean_cache,
@@ -1621,6 +1632,8 @@ class TestRegisterCloudGuest:
         mock_get_creds_file,
         mock_os_unlink,
         mock_set_proxy,
+        mock_has_nvidia_support,
+        mock_set_registration_completed_flag,
     ):
         smt_data_ipv46 = dedent(
             '''\
@@ -1634,6 +1647,7 @@ class TestRegisterCloudGuest:
 
         smt_server = SMT(etree.fromstring(smt_data_ipv46))
         mock_get_current_smt.return_value = smt_server
+        mock_has_nvidia_support.return_value = False
         fake_args = SimpleNamespace(
             clean_up=False,
             force_new_registration=True,
@@ -1726,14 +1740,18 @@ class TestRegisterCloudGuest:
         )
         mock_set_proxy.return_value = False
         mock_get_register_cmd.return_value = '/usr/sbin/SUSEConnect'
-        with raises(SystemExit) as sys_exit:
-            with tempfile.TemporaryDirectory(suffix='foo') as tdir:
-                with patch(
-                    'cloudregister.registerutils.REGISTRATION_DATA_DIR',
-                    new=tdir,
-                ):
-                    register_cloud_guest.main(fake_args)
-        assert sys_exit.value.code == 6
+        # A failed module registration does not fail the registration
+        # of the system, the process continues and does not exit
+        with tempfile.TemporaryDirectory(suffix='foo') as tdir:
+            with patch(
+                'cloudregister.registerutils.REGISTRATION_DATA_DIR',
+                new=tdir,
+            ):
+                register_cloud_guest.main(fake_args)
+        assert 'Module registration failed(repository)' in self._caplog.text
+        assert 'Registration succeeded' in self._caplog.text
+        mock_set_registration_completed_flag.assert_called_once_with()
+        mock_deregister_from_SCC.assert_not_called()
 
     @patch('cloudregister.registerutils.set_registration_completed_flag')
     @patch('cloudregister.registerutils.set_proxy')
@@ -3161,18 +3179,25 @@ class TestRegisterCloudGuest:
 
         # Test error case
         prod_reg.returncode = 1
-        with raises(SystemExit):
+        # The failure is handed to the caller, the method does not exit
+        registered_target, returncode = (
             register_cloud_guest.register_base_product(
                 registration_target,
                 instance_data_filepath,
                 commandline_args,
                 region_smt_servers,
             )
-            mock_deregister_non_free_extensions.assert_called_once_with()
-            mock_deregister_non_free_extensions.assert_called_once_with()
-            mock_deregister_from_update_infrastructure.assert_called_once_with()
-            mock_deregister_from_SCC.assert_called_once_with()
-            mock_clean_hosts_file.assert_called_once_with()
+        )
+        assert returncode == 1
+        assert 'Baseproduct registration failed' in self._caplog.text
+        # the update server the registration was attempted with last
+        assert registered_target == region_smt_servers[0]
+        # cleanup happened once, when the registration switched over to
+        # the sibling update server. The cleanup for the final failure
+        # is up to the caller
+        mock_deregister_non_free_extensions.assert_called_once_with()
+        mock_deregister_from_update_infrastructure.assert_called_once_with()
+        mock_deregister_from_SCC.assert_called_once_with()
 
     @patch('cloudregister.registerutils.deregister_non_free_extensions')
     @patch('cloudregister.registerutils.deregister_from_update_infrastructure')

--- a/test/unit/registercloudguest_test.py
+++ b/test/unit/registercloudguest_test.py
@@ -2711,7 +2711,7 @@ class TestRegisterCloudGuest:
                 [],
                 [],
             )
-            == 0
+            == 67
         )
 
     @patch('cloudregister.registerutils.register_product')
@@ -2754,7 +2754,7 @@ class TestRegisterCloudGuest:
                 [],
                 [],
             )
-            == 0
+            == 67
         )
 
     @patch('cloudregister.registerutils.register_product')


### PR DESCRIPTION
This change is three fold

Prior fixing the actual return code handling I saw the need for two refactoring steps

**Refactor use of global variable**
    
Drop using a global registration_returncode variable whose current value is hard to manage across the process of registering the system.

**Refactor register_base_product returncode handling**
    
Return from the function including a return code.

These two changes were done with help from Claude:claude-opus-4-6

The actual fix for the return code handling in a way that module registrations are not fatal was done in the last commit

**Fix registration status for module registrations**
    
Make sure module registration errors are only logged but do not fail the entire registration. Only base registration errors are handled as fatal.

This Fixes bsc#1275998

Please review carefully since some changes were needed to fix this in a good way

